### PR TITLE
Update regex to support single file link

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1321,7 +1321,7 @@ impl From<Config> for App {
             url_input: IndexMap::default(),
             expanded_files: HashMap::new(),
             route: Route::Home,
-            url_regex: Regex::new("https?://mega\\.nz/folder/([\\dA-Za-z]+)#([\\dA-Za-z-_]+)").unwrap(),
+            url_regex: Regex::new("https?://mega\\.nz/(folder|file)/([\\dA-Za-z]+)#([\\dA-Za-z-_]+)").unwrap(),
             proxy_regex: Regex::new("(?:(?:https?|socks5h?)://)(?:(?:[a-z\\d]+(?::[a-z\\d]+)?@)?)(?:(?:[a-z\\d](?:[a-z\\d\\-]{0,61}[a-z\\d])?\\.)+[a-z\\d][a-z\\d\\-]{0,61}[a-z\\d]|(?:\\d{1,3}\\.){3}\\d{1,3})(:\\d{1,5})").unwrap(),
             errors: Vec::new(),
             error_modal: None,


### PR DESCRIPTION
Test link: https://mega.nz/file/3fpFmApS#sctL8FeRfGKjBpYQPD1hPrAJz1PSvQIyINte8UKRvRk

update url_regex so that giga-grabber can parse single file link