### PR TITLE
Worker Refactor & Runner Testing

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,39 @@
+name: Code Quality Checks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Install Linux system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
+
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Run tests
+        run: cargo test --all-features --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Build Release
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [ main ]
     tags: "*"
-  pull_request:
-    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,6 +1403,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simple-logging",
+ "tempfile",
  "tokio",
  "tokio-util",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,6 @@ gui = ["dep:iced", "dep:native-dialog"]
 opt-level = 3
 lto = true
 codegen-units = 1
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "gui")]
 use crate::app::build_app;
 use crate::cli::{CliArgs, run_cli};
-use crate::config::Config;
 use crate::mega_client::{MegaClient, Node, NodeKind};
 use clap::Parser;
 use log::{LevelFilter, error};
@@ -10,17 +9,8 @@ use std::collections::HashMap;
 #[cfg(feature = "gui")]
 use std::env;
 use std::fmt::Display;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
-use std::time::Duration;
-use tokio::fs::{create_dir_all, rename};
-use tokio::sync::mpsc::Sender;
-use tokio::sync::{Mutex, Notify, RwLock, Semaphore};
+use std::path::PathBuf;
 use tokio::task::JoinHandle;
-use tokio::time::{Instant, sleep};
-use tokio::{select, spawn};
-use tokio_util::sync::CancellationToken;
 
 #[cfg(feature = "gui")]
 mod app;
@@ -38,8 +28,10 @@ mod resources;
 mod screens;
 #[cfg(feature = "gui")]
 mod styles;
+mod worker;
 
 type WorkerHandle = JoinHandle<anyhow::Result<()>>;
+pub(crate) use worker::*;
 
 #[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize, Eq, clap::ValueEnum)]
 enum ProxyMode {
@@ -108,112 +100,6 @@ impl<'a> Iterator for FileIter<'a> {
         self.stack.extend(node.children.iter().rev());
         Some(node)
     }
-}
-
-#[derive(Debug, Clone)]
-struct Download {
-    node: Node,
-    file_path: PathBuf,
-    downloaded: Arc<AtomicUsize>,
-    start: Arc<RwLock<Option<Instant>>>,
-    stop: CancellationToken,
-    pause: Arc<Notify>,
-    paused: Arc<AtomicBool>,
-    retries: Arc<AtomicU32>,
-    last_tried_at: Arc<Mutex<Option<Instant>>>,
-}
-
-impl Download {
-    fn new(file: &MegaFile) -> Self {
-        Self {
-            node: file.node.clone(),
-            file_path: file.file_path.clone(),
-            downloaded: Default::default(),
-            start: Default::default(),
-            stop: Default::default(),
-            pause: Default::default(),
-            paused: Default::default(),
-            retries: Default::default(),
-            last_tried_at: Default::default(),
-        }
-    }
-}
-
-impl Download {
-    async fn start(&self) {
-        self.start.write().await.replace(Instant::now());
-    }
-
-    async fn set_retried(&self) {
-        self.retries.fetch_add(1, Ordering::Relaxed);
-        self.last_tried_at.lock().await.replace(Instant::now());
-    }
-
-    #[cfg(feature = "gui")]
-    fn progress(&self) -> f32 {
-        if self.node.size == 0 {
-            return 0.0;
-        }
-        (self.downloaded.load(Ordering::Relaxed) as f32 / self.node.size as f32).clamp(0.0, 1.0)
-    }
-
-    #[cfg(feature = "gui")]
-    fn speed(&self) -> f32 {
-        if self.paused.load(Ordering::Relaxed) {
-            return 0_f32;
-        }
-
-        if let Some(start) = self.start.blocking_read().as_ref() {
-            let elapsed = start.elapsed().as_secs_f32();
-            if elapsed <= 0.0 {
-                return 0_f32;
-            }
-            (self.downloaded.load(Ordering::Relaxed) as f32 / elapsed) / 1_048_576.0
-        } else {
-            0_f32
-        }
-    }
-
-    #[cfg(feature = "gui")]
-    fn cancel(&self) {
-        self.stop.cancel();
-    }
-
-    #[cfg(feature = "gui")]
-    fn pause(&self) {
-        self.pause.notify_one();
-    }
-
-    #[cfg(feature = "gui")]
-    fn resume(&self) {
-        self.paused.store(false, Ordering::Relaxed);
-        // the worker will be sitting on notified
-        self.pause.notify_one();
-    }
-
-    #[cfg(feature = "gui")]
-    fn is_paused(&self) -> bool {
-        self.paused.load(Ordering::Relaxed)
-    }
-}
-
-#[derive(Debug, Clone)]
-enum RunnerMessage {
-    /// notifies UI that this download has become active
-    Active(Download),
-    /// notifies the UI that this download if finished
-    Inactive(String),
-    /// notifies the UI when non-critical errors bubble up
-    Error(String),
-    /// may be emitted during shutdown
-    #[cfg(feature = "gui")]
-    Finished,
-}
-
-enum RetryDecision {
-    Wait,
-    TryNow,
-    GiveUp,
 }
 
 /// main entry point which runs the Iced UI
@@ -328,198 +214,4 @@ fn parse_files<'a>(
         .collect();
 
     MegaFile::new(node.clone(), path).add_children(children)
-}
-
-/// spawns worker tasks
-fn spawn_workers(
-    client: MegaClient,
-    config: Arc<Config>,
-    receiver: kanal::AsyncReceiver<Download>,
-    download_sender: kanal::AsyncSender<Download>,
-    message_sender: Sender<RunnerMessage>,
-    cancellation_token: CancellationToken,
-    workers: usize,
-) -> Vec<WorkerHandle> {
-    let budget = config.weighted_concurrency_budget();
-    let concurrency_sem = Arc::new(Semaphore::new(budget));
-
-    (0..workers)
-        .map(|_| {
-            spawn(worker(
-                client.clone(),
-                config.clone(),
-                receiver.clone(),
-                download_sender.clone(),
-                message_sender.clone(),
-                cancellation_token.clone(),
-                concurrency_sem.clone(),
-            ))
-        })
-        .collect()
-}
-
-/// downloads one file at a time from the channel
-/// may be canceled at any time by the token
-async fn worker(
-    client: MegaClient,
-    config: Arc<Config>,
-    receiver: kanal::AsyncReceiver<Download>,
-    download_sender: kanal::AsyncSender<Download>,
-    message_sender: Sender<RunnerMessage>,
-    cancellation_token: CancellationToken,
-    concurrency_sem: Arc<Semaphore>,
-) -> anyhow::Result<()> {
-    loop {
-        select! {
-            _ = cancellation_token.cancelled() => break,
-            Ok(download) = receiver.recv() => {
-                if download.stop.is_cancelled() {
-                    continue;
-                }
-
-                let since_last_retry = download.last_tried_at.lock().await.as_ref().map(|i| i.elapsed());
-                if let Some(elapsed) = since_last_retry {
-                    let retries = download.retries.load(Ordering::Relaxed);
-                    match retry_decision(elapsed, retries, &config) {
-                        RetryDecision::Wait => {
-                             // avoid hammering workers with the same task
-                            if download_sender.len() < config.max_workers_bounded() {
-                                sleep(Duration::from_millis(10)).await;
-                            }
-                            // requeue download
-                            download_sender.send(download).await?;
-                            continue;
-                        }
-                        RetryDecision::TryNow => {
-                            // proceed
-                        }
-                        RetryDecision::GiveUp => {
-                            // report the error to the UI
-                            message_sender.send(RunnerMessage::Error(
-                                format!("Max retries reached for {}", download.node.name)
-                            )).await?;
-                            // report as Inactive to help CLI track completion
-                            message_sender.send(RunnerMessage::Inactive(download.node.handle)).await?;
-                            continue;
-                        }
-                    }
-                }
-
-                // create file path for the node
-                let file_path = Path::new("downloads").join(&download.file_path);
-                // create folders if needed
-                create_dir_all(&file_path).await?;
-
-                // full file path to partial file
-                let partial_path = file_path.join(format!("{}.partial", download.node.name));
-                // full path to final destination
-                let full_path = file_path.join(&download.node.name);
-                // this download is already complete
-                if full_path.exists() {
-                    // report as Inactive to help CLI track completion
-                    message_sender.send(RunnerMessage::Inactive(download.node.handle)).await?;
-                    continue;
-                }
-
-                // figure out size & weight before downloading.
-                let size_bytes = download.node.size;
-                let weight = config.download_weight(size_bytes);
-
-                // acquire weighted permits, but be cancel-aware.
-                let _permits = {
-                    let sem = concurrency_sem.clone();
-                    select! {
-                        _ = cancellation_token.cancelled() => {
-                            break;
-                        }
-                        _ = download.stop.cancelled() => {
-                            continue;
-                        }
-                        res = sem.acquire_many_owned(weight as u32) => {
-                            res?
-                        }
-                    }
-                };
-
-                // mark the download as started
-                download.start().await;
-                // alert the UI of the change
-                message_sender.send(RunnerMessage::Active(download.clone())).await?;
-
-                select! {
-                    // abort entire worker when canceled
-                    _ = cancellation_token.cancelled() => break,
-                    // abort download when individually stopped
-                    _ = download.stop.cancelled() => (),
-                    result = client.download_file(&download, &partial_path) => {
-                        match result {
-                            // the partial file now contains the full contents of the download
-                            Ok(true) => {
-                                if let Err(error) = rename(partial_path, full_path).await {
-                                    error!("Error renaming file: {error:?}");
-                                }
-                            }
-                            // the download has been paused
-                            Ok(false) => {
-                                // wait for download to unpause
-                                // respect cancellation & stops
-                                select! {
-                                    _ = cancellation_token.cancelled() => break,
-                                    _ = download.stop.cancelled() => continue,
-                                    _ = download.pause.notified() => ()
-                                }
-                                // requeue download
-                                download_sender.send(download).await?;
-                                continue;
-                            }
-                            Err(error) => {
-                                error!("Error downloading file: {error:?}");
-                                // keep track of per-download retries
-                                download.set_retried().await;
-                                // report error to UI
-                                message_sender.send(RunnerMessage::Error(error.to_string())).await?;
-                                // requeue download
-                                download_sender.send(download).await?;
-                                continue;
-                            }
-                        }
-                    }
-                }
-
-                // in every case, we want the UI to mark this download inactive
-                message_sender.send(RunnerMessage::Inactive(download.node.handle)).await?
-            }
-            else => break,
-        }
-    }
-
-    Ok(())
-}
-
-fn retry_decision(
-    elapsed_since_last_retry: Duration,
-    retries: u32,
-    config: &Config,
-) -> RetryDecision {
-    if retries >= config.max_retries {
-        return RetryDecision::GiveUp;
-    }
-
-    let exp = retries.min(31);
-    let factor = 1u32 << exp;
-
-    let base_delay = match config.min_retry_delay.checked_mul(factor) {
-        Some(d) => d,
-        None => config.max_retry_delay,
-    };
-
-    let required_delay = base_delay
-        .max(config.min_retry_delay)
-        .min(config.max_retry_delay);
-
-    if elapsed_since_last_retry >= required_delay {
-        RetryDecision::TryNow
-    } else {
-        RetryDecision::Wait
-    }
 }

--- a/src/mega_client.rs
+++ b/src/mega_client.rs
@@ -97,6 +97,15 @@ impl MegaClient {
         })
     }
 
+    #[cfg(test)]
+    pub(crate) fn with_origin(http: reqwest::Client, origin: Url) -> Self {
+        Self {
+            http,
+            origin,
+            id_counter: Default::default(),
+        }
+    }
+
     fn next_request_id(&self) -> u64 {
         self.id_counter.fetch_add(1, Ordering::SeqCst)
     }

--- a/src/mega_client.rs
+++ b/src/mega_client.rs
@@ -1,4 +1,4 @@
-use crate::Download;
+use crate::worker::{Download, PauseState};
 use aes::Aes128;
 use anyhow::{Context, Result, bail};
 use base64::Engine;
@@ -19,6 +19,7 @@ use std::sync::atomic::Ordering::Relaxed;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::fs::OpenOptions;
 use tokio::io::{AsyncSeekExt, AsyncWriteExt};
+use tokio::sync::watch;
 use tokio::{fs, select};
 use url::Url;
 
@@ -45,6 +46,23 @@ pub(crate) struct Node {
     aes_key: [u8; 16],
     aes_iv: Option<[u8; 8]>,
     pub(crate) root_handle: String,
+}
+
+#[cfg(test)]
+impl Node {
+    pub(crate) fn test_file(handle: impl Into<String>, name: impl Into<String>, size: u64) -> Self {
+        let handle = handle.into();
+        Self {
+            name: name.into(),
+            handle: handle.clone(),
+            parent: Some("root".to_string()),
+            kind: NodeKind::File,
+            size,
+            aes_key: [0; 16],
+            aes_iv: Some([0; 8]),
+            root_handle: handle,
+        }
+    }
 }
 
 /// What kind of public link this is
@@ -156,17 +174,20 @@ impl MegaClient {
             req = req.header(header::RANGE, range_header);
         }
 
+        let mut pause_receiver = download.pause_receiver();
+
         let resp = select! {
+            _ = pause_loop(&mut pause_receiver) => {
+                // Pause may have been resumed concurrently; only persist Paused
+                // when a pause intent is still current.
+                download.mark_paused_if_requested();
+                return Ok(false);
+            }
             result = req.send() => {
                 result
                     .context("MEGA file download request failed")?
                     .error_for_status()
                     .context("MEGA file download HTTP error")?
-            }
-            _ = download.pause.notified() => {
-                // the download is paused now
-                download.paused.store(true, Relaxed);
-                return Ok(false);
             }
         };
 
@@ -182,9 +203,10 @@ impl MegaClient {
 
         loop {
             select! {
-                _ = download.pause.notified() => {
-                    // the download is paused now
-                    download.paused.store(true, Relaxed);
+                _ = pause_loop(&mut pause_receiver) => {
+                    // Pause may have been resumed concurrently; only persist Paused
+                    // when a pause intent is still current.
+                    download.mark_paused_if_requested();
                     return Ok(false);
                 }
                 chunk_option = stream.next() => {
@@ -639,4 +661,16 @@ fn decrypt_attrs(aes_key: &[u8; 16], attr_b64: &str) -> Result<String> {
         serde_json::from_slice(json_bytes).context("parsing node attributes JSON")?;
 
     Ok(attrs.name)
+}
+
+async fn pause_loop(pause_receiver: &mut watch::Receiver<PauseState>) {
+    loop {
+        let state = *pause_receiver.borrow();
+        if matches!(state, PauseState::PauseRequested | PauseState::Paused) {
+            break;
+        }
+        if pause_receiver.changed().await.is_err() {
+            break;
+        }
+    }
 }

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use std::time::Duration;
-use tokio::fs::{create_dir_all, rename};
+use tokio::fs::{create_dir_all, rename, try_exists};
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{Mutex, RwLock, Semaphore, watch};
 use tokio::time::{Instant, sleep};
@@ -247,7 +247,7 @@ pub(crate) async fn worker<D: DownloadDriver>(
                 // full path to final destination
                 let full_path = file_path.join(&download.node.name);
                 // this download is already complete
-                if full_path.exists() {
+                if try_exists(&full_path).await? {
                     // report as Inactive to help CLI track completion
                     message_sender.send(RunnerMessage::Inactive(download.node.handle)).await?;
                     continue;

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -109,10 +109,6 @@ impl Download {
         *self.pause_state.borrow()
     }
 
-    pub(crate) fn mark_paused(&self) {
-        let _ = self.pause_state.send_replace(PauseState::Paused);
-    }
-
     pub(crate) fn mark_paused_if_requested(&self) -> bool {
         let _ = self.pause_state.send_if_modified(|state| {
             if *state == PauseState::PauseRequested {
@@ -162,7 +158,7 @@ impl DownloadDriver for MegaClient {
         download: &Download,
         dest_path: &Path,
     ) -> impl Future<Output = anyhow::Result<bool>> + Send {
-        async move { MegaClient::download_file(self, download, dest_path).await }
+        MegaClient::download_file(self, download, dest_path)
     }
 }
 
@@ -373,7 +369,7 @@ pub(crate) fn retry_decision(
 
 #[cfg(test)]
 pub(crate) mod fake {
-    use super::{Download, DownloadDriver, PauseState};
+    use super::{Download, DownloadDriver};
     use anyhow::anyhow;
     use std::collections::VecDeque;
     use std::path::Path;
@@ -408,6 +404,37 @@ pub(crate) mod fake {
         pub(crate) fn call_count(&self) -> usize {
             self.call_count.load(Ordering::Relaxed)
         }
+
+        async fn run_action(&self, download: &Download) -> anyhow::Result<bool> {
+            self.call_count.fetch_add(1, Ordering::Relaxed);
+            let action = self
+                .actions
+                .lock()
+                .await
+                .pop_front()
+                .unwrap_or(DriverAction::Complete);
+            match action {
+                DriverAction::Complete => Ok(true),
+                DriverAction::Pause => {
+                    download.pause();
+                    download.mark_paused_if_requested();
+                    Ok(false)
+                }
+                DriverAction::PauseThenQuickResume => {
+                    download.pause();
+                    download.resume();
+                    download.mark_paused_if_requested();
+                    Ok(false)
+                }
+                DriverAction::Fail(message) => Err(anyhow!(message)),
+                DriverAction::Hang => loop {
+                    if download.stop.is_cancelled() {
+                        return Ok(true);
+                    }
+                    sleep(Duration::from_millis(50)).await;
+                },
+            }
+        }
     }
 
     impl DownloadDriver for FakeDriver {
@@ -416,37 +443,7 @@ pub(crate) mod fake {
             download: &Download,
             _dest_path: &Path,
         ) -> impl std::future::Future<Output = anyhow::Result<bool>> + Send {
-            async move {
-                self.call_count.fetch_add(1, Ordering::Relaxed);
-                let action = self
-                    .actions
-                    .lock()
-                    .await
-                    .pop_front()
-                    .unwrap_or(DriverAction::Complete);
-                match action {
-                    DriverAction::Complete => Ok(true),
-                    DriverAction::Pause => {
-                        if download.pause_state() != PauseState::Paused {
-                            download.mark_paused();
-                        }
-                        Ok(false)
-                    }
-                    DriverAction::PauseThenQuickResume => {
-                        download.pause();
-                        download.resume();
-                        download.mark_paused_if_requested();
-                        Ok(false)
-                    }
-                    DriverAction::Fail(message) => Err(anyhow!(message)),
-                    DriverAction::Hang => loop {
-                        if download.stop.is_cancelled() {
-                            return Ok(true);
-                        }
-                        sleep(Duration::from_millis(50)).await;
-                    },
-                }
-            }
+            self.run_action(download)
         }
     }
 }

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -1,0 +1,455 @@
+use crate::config::Config;
+use crate::mega_client::MegaClient;
+use crate::{MegaFile, WorkerHandle};
+use log::error;
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+use std::time::Duration;
+use tokio::fs::{create_dir_all, rename};
+use tokio::sync::mpsc::Sender;
+use tokio::sync::{Mutex, RwLock, Semaphore, watch};
+use tokio::time::{Instant, sleep};
+use tokio::{select, spawn};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PauseState {
+    Running,
+    PauseRequested,
+    Paused,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Download {
+    pub(crate) node: crate::mega_client::Node,
+    pub(crate) file_path: PathBuf,
+    pub(crate) downloaded: Arc<AtomicUsize>,
+    start: Arc<RwLock<Option<Instant>>>,
+    pub(crate) stop: CancellationToken,
+    pause_state: Arc<watch::Sender<PauseState>>,
+    retries: Arc<AtomicU32>,
+    last_tried_at: Arc<Mutex<Option<Instant>>>,
+}
+
+impl Download {
+    pub(crate) fn new(file: &MegaFile) -> Self {
+        let (pause_state, _) = watch::channel(PauseState::Running);
+        Self {
+            node: file.node.clone(),
+            file_path: file.file_path.clone(),
+            downloaded: Default::default(),
+            start: Default::default(),
+            stop: Default::default(),
+            pause_state: Arc::new(pause_state),
+            retries: Default::default(),
+            last_tried_at: Default::default(),
+        }
+    }
+}
+
+impl Download {
+    pub(crate) async fn start(&self) {
+        self.start.write().await.replace(Instant::now());
+    }
+
+    pub(crate) async fn set_retried(&self) {
+        self.retries.fetch_add(1, Ordering::Relaxed);
+        self.last_tried_at.lock().await.replace(Instant::now());
+    }
+
+    #[cfg(feature = "gui")]
+    pub(crate) fn progress(&self) -> f32 {
+        if self.node.size == 0 {
+            return 0.0;
+        }
+        (self.downloaded.load(Ordering::Relaxed) as f32 / self.node.size as f32).clamp(0.0, 1.0)
+    }
+
+    #[cfg(feature = "gui")]
+    pub(crate) fn speed(&self) -> f32 {
+        if self.is_paused() {
+            return 0_f32;
+        }
+
+        if let Some(start) = self.start.blocking_read().as_ref() {
+            let elapsed = start.elapsed().as_secs_f32();
+            if elapsed <= 0.0 {
+                return 0_f32;
+            }
+            (self.downloaded.load(Ordering::Relaxed) as f32 / elapsed) / 1_048_576.0
+        } else {
+            0_f32
+        }
+    }
+
+    #[cfg(feature = "gui")]
+    pub(crate) fn cancel(&self) {
+        self.stop.cancel();
+    }
+
+    pub(crate) fn pause(&self) {
+        let _ = self.pause_state.send_replace(PauseState::PauseRequested);
+    }
+
+    pub(crate) fn resume(&self) {
+        let _ = self.pause_state.send_replace(PauseState::Running);
+    }
+
+    pub(crate) fn is_paused(&self) -> bool {
+        self.pause_state() == PauseState::Paused
+    }
+
+    pub(crate) fn pause_receiver(&self) -> watch::Receiver<PauseState> {
+        self.pause_state.subscribe()
+    }
+
+    pub(crate) fn pause_state(&self) -> PauseState {
+        *self.pause_state.borrow()
+    }
+
+    pub(crate) fn mark_paused(&self) {
+        let _ = self.pause_state.send_replace(PauseState::Paused);
+    }
+
+    pub(crate) fn mark_paused_if_requested(&self) -> bool {
+        let _ = self.pause_state.send_if_modified(|state| {
+            if *state == PauseState::PauseRequested {
+                *state = PauseState::Paused;
+                return true;
+            }
+            false
+        });
+
+        matches!(
+            self.pause_state(),
+            PauseState::PauseRequested | PauseState::Paused
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum RunnerMessage {
+    /// notifies UI that this download has become active
+    Active(Download),
+    /// notifies the UI that this download if finished
+    Inactive(String),
+    /// notifies the UI when non-critical errors bubble up
+    Error(String),
+    /// may be emitted during shutdown
+    #[cfg(feature = "gui")]
+    Finished,
+}
+
+pub(crate) enum RetryDecision {
+    Wait,
+    TryNow,
+    GiveUp,
+}
+
+pub(crate) trait DownloadDriver: Send + Sync + Clone + 'static {
+    fn download_file(
+        &self,
+        download: &Download,
+        dest_path: &Path,
+    ) -> impl Future<Output = anyhow::Result<bool>> + Send;
+}
+
+impl DownloadDriver for MegaClient {
+    fn download_file(
+        &self,
+        download: &Download,
+        dest_path: &Path,
+    ) -> impl Future<Output = anyhow::Result<bool>> + Send {
+        async move { MegaClient::download_file(self, download, dest_path).await }
+    }
+}
+
+/// spawns worker tasks
+pub(crate) fn spawn_workers<D: DownloadDriver>(
+    client: D,
+    config: Arc<Config>,
+    receiver: kanal::AsyncReceiver<Download>,
+    download_sender: kanal::AsyncSender<Download>,
+    message_sender: Sender<RunnerMessage>,
+    cancellation_token: CancellationToken,
+    workers: usize,
+) -> Vec<WorkerHandle> {
+    let budget = config.weighted_concurrency_budget();
+    let concurrency_sem = Arc::new(Semaphore::new(budget));
+
+    (0..workers)
+        .map(|_| {
+            spawn(worker(
+                client.clone(),
+                config.clone(),
+                receiver.clone(),
+                download_sender.clone(),
+                message_sender.clone(),
+                cancellation_token.clone(),
+                concurrency_sem.clone(),
+            ))
+        })
+        .collect()
+}
+
+/// downloads one file at a time from the channel
+/// may be canceled at any time by the token
+pub(crate) async fn worker<D: DownloadDriver>(
+    client: D,
+    config: Arc<Config>,
+    receiver: kanal::AsyncReceiver<Download>,
+    download_sender: kanal::AsyncSender<Download>,
+    message_sender: Sender<RunnerMessage>,
+    cancellation_token: CancellationToken,
+    concurrency_sem: Arc<Semaphore>,
+) -> anyhow::Result<()> {
+    'worker: loop {
+        select! {
+            _ = cancellation_token.cancelled() => break,
+            Ok(download) = receiver.recv() => {
+                if download.stop.is_cancelled() {
+                    continue;
+                }
+
+                let since_last_retry = download.last_tried_at.lock().await.as_ref().map(|i| i.elapsed());
+                if let Some(elapsed) = since_last_retry {
+                    let retries = download.retries.load(Ordering::Relaxed);
+                    match retry_decision(elapsed, retries, &config) {
+                        RetryDecision::Wait => {
+                             // avoid hammering workers with the same task
+                            if download_sender.len() < config.max_workers_bounded() {
+                                sleep(Duration::from_millis(10)).await;
+                            }
+                            // requeue download
+                            download_sender.send(download).await?;
+                            continue;
+                        }
+                        RetryDecision::TryNow => {
+                            // proceed
+                        }
+                        RetryDecision::GiveUp => {
+                            // report the error to the UI
+                            message_sender.send(RunnerMessage::Error(
+                                format!("Max retries reached for {}", download.node.name)
+                            )).await?;
+                            // report as Inactive to help CLI track completion
+                            message_sender.send(RunnerMessage::Inactive(download.node.handle)).await?;
+                            continue;
+                        }
+                    }
+                }
+
+                // create file path for the node
+                let file_path = Path::new("downloads").join(&download.file_path);
+                // create folders if needed
+                create_dir_all(&file_path).await?;
+
+                // full file path to partial file
+                let partial_path = file_path.join(format!("{}.partial", download.node.name));
+                // full path to final destination
+                let full_path = file_path.join(&download.node.name);
+                // this download is already complete
+                if full_path.exists() {
+                    // report as Inactive to help CLI track completion
+                    message_sender.send(RunnerMessage::Inactive(download.node.handle)).await?;
+                    continue;
+                }
+
+                // figure out size & weight before downloading.
+                let size_bytes = download.node.size;
+                let weight = config.download_weight(size_bytes);
+
+                // acquire weighted permits, but be cancel-aware.
+                let _permits = {
+                    let sem = concurrency_sem.clone();
+                    select! {
+                        _ = cancellation_token.cancelled() => {
+                            break;
+                        }
+                        _ = download.stop.cancelled() => {
+                            continue;
+                        }
+                        res = sem.acquire_many_owned(weight as u32) => {
+                            res?
+                        }
+                    }
+                };
+
+                // mark the download as started
+                download.start().await;
+                // alert the UI of the change
+                message_sender.send(RunnerMessage::Active(download.clone())).await?;
+
+                select! {
+                    // abort entire worker when canceled
+                    _ = cancellation_token.cancelled() => break,
+                    // abort download when individually stopped
+                    _ = download.stop.cancelled() => (),
+                    result = client.download_file(&download, &partial_path) => {
+                        match result {
+                            // the partial file now contains the full contents of the download
+                            Ok(true) => {
+                                if let Err(error) = rename(partial_path, full_path).await {
+                                    error!("Error renaming file: {error:?}");
+                                }
+                            }
+                            // the download has been paused
+                            Ok(false) => {
+                                // wait for download to unpause
+                                // respect cancellation & stops
+                                let mut pause_receiver = download.pause_receiver();
+                                loop {
+                                    if *pause_receiver.borrow() == PauseState::Running {
+                                        break;
+                                    }
+
+                                    select! {
+                                        _ = cancellation_token.cancelled() => break 'worker,
+                                        _ = download.stop.cancelled() => continue 'worker,
+                                        result = pause_receiver.changed() => {
+                                            if result.is_err() {
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                                // requeue download
+                                download_sender.send(download).await?;
+                                continue;
+                            }
+                            Err(error) => {
+                                error!("Error downloading file: {error:?}");
+                                // keep track of per-download retries
+                                download.set_retried().await;
+                                // report error to UI
+                                message_sender.send(RunnerMessage::Error(error.to_string())).await?;
+                                // requeue download
+                                download_sender.send(download).await?;
+                                continue;
+                            }
+                        }
+                    }
+                }
+
+                // in every case, we want the UI to mark this download inactive
+                message_sender.send(RunnerMessage::Inactive(download.node.handle)).await?
+            }
+            else => break,
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn retry_decision(
+    elapsed_since_last_retry: Duration,
+    retries: u32,
+    config: &Config,
+) -> RetryDecision {
+    if retries >= config.max_retries {
+        return RetryDecision::GiveUp;
+    }
+
+    let exp = retries.min(31);
+    let factor = 1u32 << exp;
+
+    let base_delay = match config.min_retry_delay.checked_mul(factor) {
+        Some(d) => d,
+        None => config.max_retry_delay,
+    };
+
+    let required_delay = base_delay
+        .max(config.min_retry_delay)
+        .min(config.max_retry_delay);
+
+    if elapsed_since_last_retry >= required_delay {
+        RetryDecision::TryNow
+    } else {
+        RetryDecision::Wait
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod fake {
+    use super::{Download, DownloadDriver, PauseState};
+    use anyhow::anyhow;
+    use std::collections::VecDeque;
+    use std::path::Path;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Mutex;
+    use tokio::time::{Duration, sleep};
+
+    #[derive(Debug, Clone)]
+    pub(crate) enum DriverAction {
+        Complete,
+        Pause,
+        PauseThenQuickResume,
+        Fail(String),
+        Hang,
+    }
+
+    #[derive(Clone)]
+    pub(crate) struct FakeDriver {
+        actions: Arc<Mutex<VecDeque<DriverAction>>>,
+        call_count: Arc<AtomicUsize>,
+    }
+
+    impl FakeDriver {
+        pub(crate) fn new(actions: VecDeque<DriverAction>) -> Self {
+            Self {
+                actions: Arc::new(Mutex::new(actions)),
+                call_count: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        pub(crate) fn call_count(&self) -> usize {
+            self.call_count.load(Ordering::Relaxed)
+        }
+    }
+
+    impl DownloadDriver for FakeDriver {
+        fn download_file(
+            &self,
+            download: &Download,
+            _dest_path: &Path,
+        ) -> impl std::future::Future<Output = anyhow::Result<bool>> + Send {
+            async move {
+                self.call_count.fetch_add(1, Ordering::Relaxed);
+                let action = self
+                    .actions
+                    .lock()
+                    .await
+                    .pop_front()
+                    .unwrap_or(DriverAction::Complete);
+                match action {
+                    DriverAction::Complete => Ok(true),
+                    DriverAction::Pause => {
+                        if download.pause_state() != PauseState::Paused {
+                            download.mark_paused();
+                        }
+                        Ok(false)
+                    }
+                    DriverAction::PauseThenQuickResume => {
+                        download.pause();
+                        download.resume();
+                        download.mark_paused_if_requested();
+                        Ok(false)
+                    }
+                    DriverAction::Fail(message) => Err(anyhow!(message)),
+                    DriverAction::Hang => loop {
+                        if download.stop.is_cancelled() {
+                            return Ok(true);
+                        }
+                        sleep(Duration::from_millis(50)).await;
+                    },
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -289,6 +289,15 @@ pub(crate) async fn worker<D: DownloadDriver>(
                             Ok(true) => {
                                 if let Err(error) = rename(partial_path, full_path).await {
                                     error!("Error renaming file: {error:?}");
+                                    // treat rename failures as retryable errors so we do not
+                                    // mark the download complete before the final file exists.
+                                    download.set_retried().await;
+                                    message_sender
+                                        .send(RunnerMessage::Error(error.to_string()))
+                                        .await?;
+                                    // requeue download
+                                    download_sender.send(download).await?;
+                                    continue;
                                 }
                             }
                             // the download has been paused
@@ -386,6 +395,7 @@ pub(crate) mod fake {
     #[derive(Debug, Clone)]
     pub(crate) enum DriverAction {
         Complete,
+        CompleteWithoutPartial,
         Pause,
         PauseThenQuickResume,
         Fail(String),
@@ -410,7 +420,7 @@ pub(crate) mod fake {
             self.call_count.load(Ordering::Relaxed)
         }
 
-        async fn run_action(&self, download: &Download) -> anyhow::Result<bool> {
+        async fn run_action(&self, download: &Download, dest_path: &Path) -> anyhow::Result<bool> {
             self.call_count.fetch_add(1, Ordering::Relaxed);
             let action = self
                 .actions
@@ -419,7 +429,14 @@ pub(crate) mod fake {
                 .pop_front()
                 .unwrap_or(DriverAction::Complete);
             match action {
-                DriverAction::Complete => Ok(true),
+                DriverAction::Complete => {
+                    if let Some(parent) = dest_path.parent() {
+                        tokio::fs::create_dir_all(parent).await?;
+                    }
+                    tokio::fs::write(dest_path, b"fake").await?;
+                    Ok(true)
+                }
+                DriverAction::CompleteWithoutPartial => Ok(true),
                 DriverAction::Pause => {
                     download.pause();
                     download.mark_paused_if_requested();
@@ -446,9 +463,9 @@ pub(crate) mod fake {
         fn download_file(
             &self,
             download: &Download,
-            _dest_path: &Path,
+            dest_path: &Path,
         ) -> impl std::future::Future<Output = anyhow::Result<bool>> + Send {
-            self.run_action(download)
+            self.run_action(download, dest_path)
         }
     }
 }

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -303,7 +303,12 @@ pub(crate) async fn worker<D: DownloadDriver>(
 
                                     select! {
                                         _ = cancellation_token.cancelled() => break 'worker,
-                                        _ = download.stop.cancelled() => continue 'worker,
+                                        _ = download.stop.cancelled() => {
+                                            message_sender
+                                                .send(RunnerMessage::Inactive(download.node.handle.clone()))
+                                                .await?;
+                                            continue 'worker;
+                                        }
                                         result = pause_receiver.changed() => {
                                             if result.is_err() {
                                                 break;

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -90,7 +90,13 @@ impl Download {
     }
 
     pub(crate) fn pause(&self) {
-        let _ = self.pause_state.send_replace(PauseState::PauseRequested);
+        let _ = self.pause_state.send_if_modified(|state| {
+            if *state == PauseState::Running {
+                *state = PauseState::PauseRequested;
+                return true;
+            }
+            false
+        });
     }
 
     pub(crate) fn resume(&self) {
@@ -98,7 +104,10 @@ impl Download {
     }
 
     pub(crate) fn is_paused(&self) -> bool {
-        self.pause_state() == PauseState::Paused
+        matches!(
+            self.pause_state(),
+            PauseState::PauseRequested | PauseState::Paused
+        )
     }
 
     pub(crate) fn pause_receiver(&self) -> watch::Receiver<PauseState> {
@@ -287,13 +296,13 @@ pub(crate) async fn worker<D: DownloadDriver>(
                         match result {
                             // the partial file now contains the full contents of the download
                             Ok(true) => {
-                                if let Err(error) = rename(partial_path, full_path).await {
+                                if let Err(error) = rename(&partial_path, full_path).await {
                                     error!("Error renaming file: {error:?}");
                                     // treat rename failures as retryable errors so we do not
                                     // mark the download complete before the final file exists.
                                     download.set_retried().await;
                                     message_sender
-                                        .send(RunnerMessage::Error(error.to_string()))
+                                        .send(RunnerMessage::Error(format!("Error renaming file {partial_path:?}: {error:?}")))
                                         .await?;
                                     // requeue download
                                     download_sender.send(download).await?;

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -129,7 +129,7 @@ impl Download {
 pub(crate) enum RunnerMessage {
     /// notifies UI that this download has become active
     Active(Download),
-    /// notifies the UI that this download if finished
+    /// notifies the UI that this download is finished
     Inactive(String),
     /// notifies the UI when non-critical errors bubble up
     Error(String),

--- a/src/worker/tests.rs
+++ b/src/worker/tests.rs
@@ -1,0 +1,634 @@
+use super::fake::{DriverAction, FakeDriver};
+use super::{Download, PauseState, RunnerMessage, spawn_workers};
+use crate::MegaFile;
+use crate::config::Config;
+use crate::mega_client::Node;
+use std::collections::VecDeque;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::sync::mpsc::{Receiver, channel};
+use tokio::time::{sleep, timeout};
+use tokio_util::sync::CancellationToken;
+
+fn make_download(name: &str, size: u64, dir: PathBuf) -> Download {
+    let node = Node::test_file(format!("handle-{name}"), name.to_string(), size);
+    let file = MegaFile::new(node, dir);
+    Download::new(&file)
+}
+
+fn make_driver(actions: Vec<DriverAction>) -> FakeDriver {
+    FakeDriver::new(VecDeque::from(actions))
+}
+
+async fn next_message(receiver: &mut Receiver<RunnerMessage>) -> RunnerMessage {
+    timeout(Duration::from_secs(5), receiver.recv())
+        .await
+        .expect("message timeout")
+        .expect("message channel closed")
+}
+
+async fn wait_for_paused(download: &Download) {
+    timeout(Duration::from_secs(3), async {
+        loop {
+            if download.pause_state() == PauseState::Paused {
+                return;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("pause state was never reached");
+}
+
+async fn wait_for_inactive(receiver: &mut Receiver<RunnerMessage>, expected: usize) {
+    let mut inactive = 0usize;
+    while inactive < expected {
+        if matches!(next_message(receiver).await, RunnerMessage::Inactive(_)) {
+            inactive += 1;
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_single_download_completes() {
+    let temp = TempDir::new().expect("temp dir");
+    let download = make_download("single.bin", 1024, temp.path().to_path_buf());
+    let driver = make_driver(vec![DriverAction::Complete]);
+    let (download_sender, download_receiver) = kanal::unbounded_async();
+    let (message_sender, mut message_receiver) = channel(32);
+    let cancel = CancellationToken::new();
+    let config = Arc::new(Config::default());
+
+    let workers = spawn_workers(
+        driver.clone(),
+        config,
+        download_receiver,
+        download_sender.clone(),
+        message_sender,
+        cancel.clone(),
+        1,
+    );
+
+    download_sender
+        .send(download.clone())
+        .await
+        .expect("enqueue download");
+
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Active(_)
+    ));
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Inactive(_)
+    ));
+
+    cancel.cancel();
+    for worker in workers {
+        worker.await.expect("worker join").expect("worker result");
+    }
+}
+
+#[tokio::test]
+async fn test_download_already_complete() {
+    let temp = TempDir::new().expect("temp dir");
+    let download = make_download("already.bin", 2048, temp.path().to_path_buf());
+    let file_path = download.file_path.join(&download.node.name);
+    tokio::fs::create_dir_all(&download.file_path)
+        .await
+        .expect("create dir");
+    tokio::fs::write(&file_path, b"done")
+        .await
+        .expect("create existing file");
+
+    let driver = make_driver(vec![DriverAction::Complete]);
+    let (download_sender, download_receiver) = kanal::unbounded_async();
+    let (message_sender, mut message_receiver) = channel(32);
+    let cancel = CancellationToken::new();
+    let config = Arc::new(Config::default());
+    let workers = spawn_workers(
+        driver.clone(),
+        config,
+        download_receiver,
+        download_sender.clone(),
+        message_sender,
+        cancel.clone(),
+        1,
+    );
+
+    download_sender
+        .send(download)
+        .await
+        .expect("enqueue download");
+
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Inactive(_)
+    ));
+    assert_eq!(driver.call_count(), 0);
+
+    cancel.cancel();
+    for worker in workers {
+        worker.await.expect("worker join").expect("worker result");
+    }
+}
+
+#[tokio::test]
+async fn test_cancel_before_active() {
+    let temp = TempDir::new().expect("temp dir");
+    let download = make_download("cancel-before.bin", 1024, temp.path().to_path_buf());
+    download.stop.cancel();
+
+    let driver = make_driver(vec![DriverAction::Complete]);
+    let (download_sender, download_receiver) = kanal::unbounded_async();
+    let (message_sender, mut message_receiver) = channel(32);
+    let cancel = CancellationToken::new();
+    let config = Arc::new(Config::default());
+    let workers = spawn_workers(
+        driver.clone(),
+        config,
+        download_receiver,
+        download_sender.clone(),
+        message_sender,
+        cancel.clone(),
+        1,
+    );
+
+    download_sender
+        .send(download)
+        .await
+        .expect("enqueue download");
+    sleep(Duration::from_millis(150)).await;
+    assert!(message_receiver.try_recv().is_err());
+    assert_eq!(driver.call_count(), 0);
+
+    cancel.cancel();
+    for worker in workers {
+        worker.await.expect("worker join").expect("worker result");
+    }
+}
+
+#[tokio::test]
+async fn test_cancel_while_active() {
+    let temp = TempDir::new().expect("temp dir");
+    let download = make_download("cancel-active.bin", 1024, temp.path().to_path_buf());
+    let driver = make_driver(vec![DriverAction::Hang]);
+    let (download_sender, download_receiver) = kanal::unbounded_async();
+    let (message_sender, mut message_receiver) = channel(32);
+    let cancel = CancellationToken::new();
+    let config = Arc::new(Config::default());
+    let workers = spawn_workers(
+        driver,
+        config,
+        download_receiver,
+        download_sender.clone(),
+        message_sender,
+        cancel.clone(),
+        1,
+    );
+
+    download_sender
+        .send(download.clone())
+        .await
+        .expect("enqueue download");
+
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Active(_)
+    ));
+    download.stop.cancel();
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Inactive(_)
+    ));
+
+    cancel.cancel();
+    for worker in workers {
+        worker.await.expect("worker join").expect("worker result");
+    }
+}
+
+#[tokio::test]
+async fn test_pause_and_resume() {
+    let temp = TempDir::new().expect("temp dir");
+    let download = make_download("pause-resume.bin", 1024, temp.path().to_path_buf());
+    let driver = make_driver(vec![DriverAction::Pause, DriverAction::Complete]);
+    let (download_sender, download_receiver) = kanal::unbounded_async();
+    let (message_sender, mut message_receiver) = channel(64);
+    let cancel = CancellationToken::new();
+    let config = Arc::new(Config::default());
+    let workers = spawn_workers(
+        driver,
+        config,
+        download_receiver,
+        download_sender.clone(),
+        message_sender,
+        cancel.clone(),
+        1,
+    );
+
+    download_sender
+        .send(download.clone())
+        .await
+        .expect("enqueue download");
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Active(_)
+    ));
+
+    wait_for_paused(&download).await;
+    assert!(download.is_paused());
+
+    download.resume();
+
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Active(_)
+    ));
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Inactive(_)
+    ));
+
+    cancel.cancel();
+    for worker in workers {
+        worker.await.expect("worker join").expect("worker result");
+    }
+}
+
+#[tokio::test]
+async fn test_quick_pause_then_single_resume_requeues_and_completes() {
+    let temp = TempDir::new().expect("temp dir");
+    let download = make_download("quick-pause-resume.bin", 1024, temp.path().to_path_buf());
+    let driver = make_driver(vec![
+        DriverAction::PauseThenQuickResume,
+        DriverAction::Complete,
+    ]);
+    let (download_sender, download_receiver) = kanal::unbounded_async();
+    let (message_sender, mut message_receiver) = channel(64);
+    let cancel = CancellationToken::new();
+    let config = Arc::new(Config::default());
+    let workers = spawn_workers(
+        driver.clone(),
+        config,
+        download_receiver,
+        download_sender.clone(),
+        message_sender,
+        cancel.clone(),
+        1,
+    );
+
+    download_sender
+        .send(download)
+        .await
+        .expect("enqueue download");
+
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Active(_)
+    ));
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Active(_)
+    ));
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Inactive(_)
+    ));
+    assert_eq!(driver.call_count(), 2);
+
+    cancel.cancel();
+    for worker in workers {
+        worker.await.expect("worker join").expect("worker result");
+    }
+}
+
+#[tokio::test]
+async fn test_pause_then_cancel() {
+    let temp = TempDir::new().expect("temp dir");
+    let download = make_download("pause-cancel.bin", 1024, temp.path().to_path_buf());
+    let driver = make_driver(vec![DriverAction::Pause]);
+    let (download_sender, download_receiver) = kanal::unbounded_async();
+    let (message_sender, mut message_receiver) = channel(32);
+    let cancel = CancellationToken::new();
+    let config = Arc::new(Config::default());
+    let workers = spawn_workers(
+        driver,
+        config,
+        download_receiver,
+        download_sender.clone(),
+        message_sender,
+        cancel.clone(),
+        1,
+    );
+
+    download_sender
+        .send(download.clone())
+        .await
+        .expect("enqueue download");
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Active(_)
+    ));
+    wait_for_paused(&download).await;
+    download.stop.cancel();
+
+    let maybe_msg = timeout(Duration::from_millis(300), message_receiver.recv()).await;
+    assert!(maybe_msg.is_err(), "unexpected message after pause-cancel");
+
+    cancel.cancel();
+    for worker in workers {
+        worker.await.expect("worker join").expect("worker result");
+    }
+}
+
+#[tokio::test]
+async fn test_retry_on_error() {
+    let temp = TempDir::new().expect("temp dir");
+    let download = make_download("retry-success.bin", 1024, temp.path().to_path_buf());
+    let driver = make_driver(vec![
+        DriverAction::Fail("first".to_string()),
+        DriverAction::Fail("second".to_string()),
+        DriverAction::Complete,
+    ]);
+    let (download_sender, download_receiver) = kanal::unbounded_async();
+    let (message_sender, mut message_receiver) = channel(64);
+    let cancel = CancellationToken::new();
+
+    let mut config = Config::default();
+    config.max_retries = 3;
+    config.min_retry_delay = Duration::ZERO;
+    config.max_retry_delay = Duration::from_millis(1);
+
+    let workers = spawn_workers(
+        driver.clone(),
+        Arc::new(config),
+        download_receiver,
+        download_sender.clone(),
+        message_sender,
+        cancel.clone(),
+        1,
+    );
+
+    download_sender
+        .send(download)
+        .await
+        .expect("enqueue download");
+    wait_for_inactive(&mut message_receiver, 1).await;
+    assert_eq!(driver.call_count(), 3);
+
+    cancel.cancel();
+    for worker in workers {
+        worker.await.expect("worker join").expect("worker result");
+    }
+}
+
+#[tokio::test]
+async fn test_max_retries_exceeded() {
+    let temp = TempDir::new().expect("temp dir");
+    let download = make_download("retry-fail.bin", 1024, temp.path().to_path_buf());
+    let driver = make_driver(vec![
+        DriverAction::Fail("first".to_string()),
+        DriverAction::Fail("second".to_string()),
+        DriverAction::Fail("third".to_string()),
+    ]);
+    let (download_sender, download_receiver) = kanal::unbounded_async();
+    let (message_sender, mut message_receiver) = channel(64);
+    let cancel = CancellationToken::new();
+
+    let mut config = Config::default();
+    config.max_retries = 2;
+    config.min_retry_delay = Duration::ZERO;
+    config.max_retry_delay = Duration::from_millis(1);
+
+    let workers = spawn_workers(
+        driver.clone(),
+        Arc::new(config),
+        download_receiver,
+        download_sender.clone(),
+        message_sender,
+        cancel.clone(),
+        1,
+    );
+
+    download_sender
+        .send(download)
+        .await
+        .expect("enqueue download");
+
+    let mut saw_max_retries_error = false;
+    let mut saw_inactive = false;
+    while !(saw_max_retries_error && saw_inactive) {
+        match next_message(&mut message_receiver).await {
+            RunnerMessage::Error(error) => {
+                if error.contains("Max retries reached") {
+                    saw_max_retries_error = true;
+                }
+            }
+            RunnerMessage::Inactive(_) => saw_inactive = true,
+            RunnerMessage::Active(_) => (),
+            #[cfg(feature = "gui")]
+            RunnerMessage::Finished => (),
+        }
+    }
+    assert_eq!(driver.call_count(), 2);
+
+    cancel.cancel();
+    for worker in workers {
+        worker.await.expect("worker join").expect("worker result");
+    }
+}
+
+#[tokio::test]
+async fn test_global_cancel_stops_all_workers() {
+    let temp = TempDir::new().expect("temp dir");
+    let driver = make_driver(vec![
+        DriverAction::Hang,
+        DriverAction::Hang,
+        DriverAction::Hang,
+    ]);
+    let (download_sender, download_receiver) = kanal::unbounded_async();
+    let (message_sender, _message_receiver) = channel(64);
+    let cancel = CancellationToken::new();
+    let config = Arc::new(Config::default());
+
+    let workers = spawn_workers(
+        driver,
+        config,
+        download_receiver,
+        download_sender.clone(),
+        message_sender,
+        cancel.clone(),
+        2,
+    );
+
+    for i in 0..3 {
+        let d = make_download(
+            &format!("global-cancel-{i}.bin"),
+            1024,
+            temp.path().to_path_buf(),
+        );
+        download_sender.send(d).await.expect("enqueue download");
+    }
+
+    sleep(Duration::from_millis(150)).await;
+    cancel.cancel();
+
+    for worker in workers {
+        timeout(Duration::from_secs(3), worker)
+            .await
+            .expect("worker join timeout")
+            .expect("worker join panic")
+            .expect("worker result");
+    }
+}
+
+#[tokio::test]
+async fn test_concurrency_semaphore_limits() {
+    let temp = TempDir::new().expect("temp dir");
+    let driver = make_driver(vec![
+        DriverAction::Complete,
+        DriverAction::Complete,
+        DriverAction::Complete,
+        DriverAction::Complete,
+        DriverAction::Complete,
+    ]);
+    let (download_sender, download_receiver) = kanal::unbounded_async();
+    let (message_sender, mut message_receiver) = channel(128);
+    let cancel = CancellationToken::new();
+
+    let mut config = Config::default();
+    config.concurrency_budget = 10;
+    let workers = spawn_workers(
+        driver,
+        Arc::new(config),
+        download_receiver,
+        download_sender.clone(),
+        message_sender,
+        cancel.clone(),
+        2,
+    );
+
+    for i in 0..5 {
+        let d = make_download(
+            &format!("weighted-{i}.bin"),
+            200 * 1024 * 1024,
+            temp.path().to_path_buf(),
+        );
+        download_sender.send(d).await.expect("enqueue download");
+    }
+
+    let mut active_count = 0usize;
+    let mut max_active = 0usize;
+    let mut inactive_count = 0usize;
+    while inactive_count < 5 {
+        match next_message(&mut message_receiver).await {
+            RunnerMessage::Active(_) => {
+                active_count += 1;
+                max_active = max_active.max(active_count);
+            }
+            RunnerMessage::Inactive(_) => {
+                active_count = active_count.saturating_sub(1);
+                inactive_count += 1;
+            }
+            RunnerMessage::Error(_) => (),
+            #[cfg(feature = "gui")]
+            RunnerMessage::Finished => (),
+        }
+    }
+    assert_eq!(max_active, 1);
+
+    cancel.cancel();
+    for worker in workers {
+        worker.await.expect("worker join").expect("worker result");
+    }
+}
+
+#[tokio::test]
+async fn test_pause_resume_race_no_lost_wakeup() {
+    let temp = TempDir::new().expect("temp dir");
+    let download = make_download("race.bin", 1024, temp.path().to_path_buf());
+    let driver = make_driver(vec![DriverAction::Pause, DriverAction::Complete]);
+    let (download_sender, download_receiver) = kanal::unbounded_async();
+    let (message_sender, mut message_receiver) = channel(128);
+    let cancel = CancellationToken::new();
+    let config = Arc::new(Config::default());
+
+    let workers = spawn_workers(
+        driver,
+        config,
+        download_receiver,
+        download_sender.clone(),
+        message_sender,
+        cancel.clone(),
+        1,
+    );
+
+    let stop_racer = Arc::new(AtomicBool::new(false));
+    let race_download = download.clone();
+    let stop_racer_clone = stop_racer.clone();
+    let racer = tokio::spawn(async move {
+        while !stop_racer_clone.load(Ordering::Relaxed) {
+            race_download.pause();
+            race_download.resume();
+            tokio::task::yield_now().await;
+        }
+        // Ensure we do not leave the worker parked in Paused.
+        race_download.resume();
+    });
+
+    download_sender
+        .send(download)
+        .await
+        .expect("enqueue download");
+    wait_for_inactive(&mut message_receiver, 1).await;
+    stop_racer.store(true, Ordering::Relaxed);
+    racer.await.expect("racer join");
+
+    cancel.cancel();
+    for worker in workers {
+        worker.await.expect("worker join").expect("worker result");
+    }
+}
+
+#[tokio::test]
+async fn test_multiple_workers_drain_queue() {
+    let temp = TempDir::new().expect("temp dir");
+    let driver = make_driver(vec![
+        DriverAction::Complete,
+        DriverAction::Complete,
+        DriverAction::Complete,
+        DriverAction::Complete,
+        DriverAction::Complete,
+        DriverAction::Complete,
+    ]);
+    let (download_sender, download_receiver) = kanal::unbounded_async();
+    let (message_sender, mut message_receiver) = channel(128);
+    let cancel = CancellationToken::new();
+    let config = Arc::new(Config::default());
+
+    let workers = spawn_workers(
+        driver,
+        config,
+        download_receiver,
+        download_sender.clone(),
+        message_sender,
+        cancel.clone(),
+        3,
+    );
+
+    for i in 0..6 {
+        let d = make_download(&format!("drain-{i}.bin"), 1024, temp.path().to_path_buf());
+        download_sender.send(d).await.expect("enqueue download");
+    }
+
+    wait_for_inactive(&mut message_receiver, 6).await;
+
+    cancel.cancel();
+    for worker in workers {
+        worker.await.expect("worker join").expect("worker result");
+    }
+}

--- a/src/worker/tests.rs
+++ b/src/worker/tests.rs
@@ -87,6 +87,19 @@ async fn wait_for_fixture_phase(state: &FixtureState, target: usize) {
     .expect("fixture phase timeout");
 }
 
+async fn wait_for_downloaded_at_least(download: &Download, min_bytes: usize) {
+    timeout(Duration::from_secs(5), async {
+        loop {
+            if download.downloaded.load(Ordering::Relaxed) >= min_bytes {
+                break;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("downloaded bytes threshold timeout");
+}
+
 async fn spawn_local_mega_fixture(
     encrypted_payload: Vec<u8>,
 ) -> (
@@ -311,6 +324,8 @@ async fn test_real_mega_client_pause_during_send_and_stream_then_resume_and_comp
     ));
 
     wait_for_fixture_phase(&fixture_state, 3).await;
+    // Ensure the partial file is large enough to force a non-zero resume range.
+    wait_for_downloaded_at_least(&download, 1_100_000).await;
     download.pause();
     wait_for_paused(&download).await;
     download.resume();

--- a/src/worker/tests.rs
+++ b/src/worker/tests.rs
@@ -683,6 +683,66 @@ async fn test_retry_on_error() {
 }
 
 #[tokio::test]
+async fn test_rename_failure_is_reported_and_not_marked_inactive_immediately() {
+    let temp = TempDir::new().expect("temp dir");
+    let download = make_download("rename-fail.bin", 1024, temp.path().to_path_buf());
+    let driver = make_driver(vec![DriverAction::CompleteWithoutPartial]);
+    let (download_sender, download_receiver) = kanal::unbounded_async();
+    let (message_sender, mut message_receiver) = channel(64);
+    let cancel = CancellationToken::new();
+
+    let mut config = Config::default();
+    config.max_retries = 1;
+    config.min_retry_delay = Duration::ZERO;
+    config.max_retry_delay = Duration::from_millis(1);
+
+    let workers = spawn_workers(
+        driver,
+        Arc::new(config),
+        download_receiver,
+        download_sender.clone(),
+        message_sender,
+        cancel.clone(),
+        1,
+    );
+
+    download_sender
+        .send(download)
+        .await
+        .expect("enqueue download");
+
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Active(_)
+    ));
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Error(_)
+    ));
+
+    let mut saw_max_retries_error = false;
+    let mut saw_inactive = false;
+    while !(saw_max_retries_error && saw_inactive) {
+        match next_message(&mut message_receiver).await {
+            RunnerMessage::Error(error) => {
+                if error.contains("Max retries reached") {
+                    saw_max_retries_error = true;
+                }
+            }
+            RunnerMessage::Inactive(_) => saw_inactive = true,
+            RunnerMessage::Active(_) => (),
+            #[cfg(feature = "gui")]
+            RunnerMessage::Finished => (),
+        }
+    }
+
+    cancel.cancel();
+    for worker in workers {
+        worker.await.expect("worker join").expect("worker result");
+    }
+}
+
+#[tokio::test]
 async fn test_max_retries_exceeded() {
     let temp = TempDir::new().expect("temp dir");
     let download = make_download("retry-fail.bin", 1024, temp.path().to_path_buf());

--- a/src/worker/tests.rs
+++ b/src/worker/tests.rs
@@ -654,10 +654,12 @@ async fn test_retry_on_error() {
     let (message_sender, mut message_receiver) = channel(64);
     let cancel = CancellationToken::new();
 
-    let mut config = Config::default();
-    config.max_retries = 3;
-    config.min_retry_delay = Duration::ZERO;
-    config.max_retry_delay = Duration::from_millis(1);
+    let config = Config {
+        max_retries: 3,
+        min_retry_delay: Duration::ZERO,
+        max_retry_delay: Duration::from_millis(1),
+        ..Default::default()
+    };
 
     let workers = spawn_workers(
         driver.clone(),
@@ -691,10 +693,12 @@ async fn test_rename_failure_is_reported_and_not_marked_inactive_immediately() {
     let (message_sender, mut message_receiver) = channel(64);
     let cancel = CancellationToken::new();
 
-    let mut config = Config::default();
-    config.max_retries = 1;
-    config.min_retry_delay = Duration::ZERO;
-    config.max_retry_delay = Duration::from_millis(1);
+    let config = Config {
+        max_retries: 1,
+        min_retry_delay: Duration::ZERO,
+        max_retry_delay: Duration::from_millis(1),
+        ..Default::default()
+    };
 
     let workers = spawn_workers(
         driver,
@@ -755,10 +759,12 @@ async fn test_max_retries_exceeded() {
     let (message_sender, mut message_receiver) = channel(64);
     let cancel = CancellationToken::new();
 
-    let mut config = Config::default();
-    config.max_retries = 2;
-    config.min_retry_delay = Duration::ZERO;
-    config.max_retry_delay = Duration::from_millis(1);
+    let config = Config {
+        max_retries: 2,
+        min_retry_delay: Duration::ZERO,
+        max_retry_delay: Duration::from_millis(1),
+        ..Default::default()
+    };
 
     let workers = spawn_workers(
         driver.clone(),
@@ -856,8 +862,10 @@ async fn test_concurrency_semaphore_limits() {
     let (message_sender, mut message_receiver) = channel(128);
     let cancel = CancellationToken::new();
 
-    let mut config = Config::default();
-    config.concurrency_budget = 10;
+    let config = Config {
+        concurrency_budget: 10,
+        ..Default::default()
+    };
     let workers = spawn_workers(
         driver,
         Arc::new(config),

--- a/src/worker/tests.rs
+++ b/src/worker/tests.rs
@@ -630,8 +630,10 @@ async fn test_pause_then_cancel() {
     wait_for_paused(&download).await;
     download.stop.cancel();
 
-    let maybe_msg = timeout(Duration::from_millis(300), message_receiver.recv()).await;
-    assert!(maybe_msg.is_err(), "unexpected message after pause-cancel");
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Inactive(_)
+    ));
 
     cancel.cancel();
     for worker in workers {

--- a/src/worker/tests.rs
+++ b/src/worker/tests.rs
@@ -2,16 +2,22 @@ use super::fake::{DriverAction, FakeDriver};
 use super::{Download, PauseState, RunnerMessage, spawn_workers};
 use crate::MegaFile;
 use crate::config::Config;
-use crate::mega_client::Node;
+use crate::mega_client::{MegaClient, Node};
+use aes::Aes128;
+use cipher::{KeyIvInit, StreamCipher};
+use ctr::Ctr128BE;
 use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
 use tokio::sync::mpsc::{Receiver, channel};
 use tokio::time::{sleep, timeout};
 use tokio_util::sync::CancellationToken;
+use url::Url;
 
 fn make_download(name: &str, size: u64, dir: PathBuf) -> Download {
     let node = Node::test_file(format!("handle-{name}"), name.to_string(), size);
@@ -50,6 +56,294 @@ async fn wait_for_inactive(receiver: &mut Receiver<RunnerMessage>, expected: usi
             inactive += 1;
         }
     }
+}
+
+fn encrypt_ctr_zero_key(payload: &[u8]) -> Vec<u8> {
+    let mut encrypted = payload.to_vec();
+    let key = [0_u8; 16];
+    let iv = [0_u8; 16];
+    let mut ctr = Ctr128BE::<Aes128>::new((&key).into(), (&iv).into());
+    ctr.apply_keystream(&mut encrypted);
+    encrypted
+}
+
+#[derive(Clone)]
+struct FixtureState {
+    saw_non_zero_range: Arc<AtomicBool>,
+    download_requests: Arc<AtomicUsize>,
+    phase: Arc<AtomicUsize>,
+}
+
+async fn wait_for_fixture_phase(state: &FixtureState, target: usize) {
+    timeout(Duration::from_secs(5), async {
+        loop {
+            if state.phase.load(Ordering::SeqCst) >= target {
+                break;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("fixture phase timeout");
+}
+
+async fn spawn_local_mega_fixture(
+    encrypted_payload: Vec<u8>,
+) -> (
+    Url,
+    FixtureState,
+    CancellationToken,
+    tokio::task::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind local fixture");
+    let addr = listener.local_addr().expect("fixture local addr");
+    let base_url = Url::parse(&format!("http://{addr}/")).expect("fixture base URL");
+
+    let state = FixtureState {
+        saw_non_zero_range: Arc::new(AtomicBool::new(false)),
+        download_requests: Arc::new(AtomicUsize::new(0)),
+        phase: Arc::new(AtomicUsize::new(0)),
+    };
+    let state_for_task = state.clone();
+    let shutdown = CancellationToken::new();
+    let shutdown_for_task = shutdown.clone();
+
+    let server = tokio::spawn(async move {
+        loop {
+            let accept_result = tokio::select! {
+                _ = shutdown_for_task.cancelled() => break,
+                result = listener.accept() => result,
+            };
+            let Ok((mut socket, _)) = accept_result else {
+                break;
+            };
+
+            let mut request = Vec::new();
+            let mut buf = [0_u8; 2048];
+            let header_end = loop {
+                let read = match socket.read(&mut buf).await {
+                    Ok(0) => break None,
+                    Ok(n) => n,
+                    Err(_) => break None,
+                };
+                request.extend_from_slice(&buf[..read]);
+                if let Some(idx) = request.windows(4).position(|w| w == b"\r\n\r\n") {
+                    break Some(idx + 4);
+                }
+            };
+            let Some(header_end) = header_end else {
+                continue;
+            };
+
+            let request_head = String::from_utf8_lossy(&request[..header_end]);
+            let mut lines = request_head.split("\r\n");
+            let request_line = lines.next().unwrap_or_default();
+            let mut parts = request_line.split_whitespace();
+            let method = parts.next().unwrap_or_default();
+            let path = parts.next().unwrap_or_default();
+
+            let mut range_start = 0usize;
+            let mut content_length = 0usize;
+            for line in lines {
+                if line.is_empty() {
+                    break;
+                }
+                if let Some((name, value)) = line.split_once(':')
+                    && name.eq_ignore_ascii_case("range")
+                {
+                    let header_val = value.trim();
+                    if let Some(raw_start) = header_val
+                        .strip_prefix("bytes=")
+                        .and_then(|rest| rest.split('-').next())
+                    {
+                        range_start = raw_start.parse::<usize>().unwrap_or(0);
+                    }
+                }
+                if let Some((name, value)) = line.split_once(':')
+                    && name.eq_ignore_ascii_case("content-length")
+                {
+                    content_length = value.trim().parse::<usize>().unwrap_or(0);
+                }
+            }
+
+            let body_read = request.len().saturating_sub(header_end);
+            if content_length > body_read {
+                let mut remaining = content_length - body_read;
+                while remaining > 0 {
+                    let read = match socket.read(&mut buf).await {
+                        Ok(0) => break,
+                        Ok(n) => n,
+                        Err(_) => break,
+                    };
+                    remaining = remaining.saturating_sub(read);
+                }
+            }
+
+            if method == "POST" && path.starts_with("/cs") {
+                let cs_body = format!(
+                    r#"[{{"g":"http://{addr}/file","s":{},"at":"QQ"}}]"#,
+                    encrypted_payload.len()
+                );
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    cs_body.len(),
+                    cs_body
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+                continue;
+            }
+
+            if method != "GET" || path != "/file" {
+                let _ = socket
+                    .write_all(
+                        b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                    )
+                    .await;
+                continue;
+            }
+
+            let request_index = state_for_task
+                .download_requests
+                .fetch_add(1, Ordering::SeqCst);
+            if range_start > 0 {
+                state_for_task
+                    .saw_non_zero_range
+                    .store(true, Ordering::SeqCst);
+            }
+
+            let start = range_start.min(encrypted_payload.len());
+            let payload = &encrypted_payload[start..];
+            let status = if start > 0 {
+                "206 Partial Content"
+            } else {
+                "200 OK"
+            };
+            let mut headers = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: application/octet-stream\r\nContent-Length: {}\r\nConnection: close\r\n",
+                payload.len()
+            );
+            if start > 0 {
+                let end = encrypted_payload.len().saturating_sub(1);
+                headers.push_str(&format!(
+                    "Content-Range: bytes {start}-{end}/{}\r\n",
+                    encrypted_payload.len()
+                ));
+            }
+            headers.push_str("\r\n");
+
+            if request_index == 0 {
+                state_for_task.phase.store(1, Ordering::SeqCst);
+                sleep(Duration::from_millis(500)).await;
+            }
+
+            let _ = socket.write_all(headers.as_bytes()).await;
+
+            if request_index == 1 {
+                state_for_task.phase.store(2, Ordering::SeqCst);
+
+                let first_chunk = payload.len().min(1_200_000);
+                let _ = socket.write_all(&payload[..first_chunk]).await;
+                let _ = socket.flush().await;
+                state_for_task.phase.store(3, Ordering::SeqCst);
+                sleep(Duration::from_millis(500)).await;
+                let _ = socket.write_all(&payload[first_chunk..]).await;
+                let _ = socket.flush().await;
+            } else {
+                let _ = socket.write_all(payload).await;
+                let _ = socket.flush().await;
+            }
+        }
+    });
+
+    (base_url, state, shutdown, server)
+}
+
+#[tokio::test]
+async fn test_real_mega_client_pause_during_send_and_stream_then_resume_and_complete() {
+    let temp = TempDir::new().expect("temp dir");
+    let expected_plain: Vec<u8> = (0..1_300_000).map(|i| (i % 251) as u8).collect();
+    let encrypted_payload = encrypt_ctr_zero_key(&expected_plain);
+
+    let (base_url, fixture_state, fixture_shutdown, fixture_task) =
+        spawn_local_mega_fixture(encrypted_payload).await;
+
+    let download = make_download(
+        "real-client-pause.bin",
+        expected_plain.len() as u64,
+        temp.path().to_path_buf(),
+    );
+    let (download_sender, download_receiver) = kanal::unbounded_async();
+    let (message_sender, mut message_receiver) = channel(64);
+    let cancel = CancellationToken::new();
+    let config = Arc::new(Config::default());
+    let mega = MegaClient::with_origin(reqwest::Client::new(), base_url);
+
+    let workers = spawn_workers(
+        mega,
+        config,
+        download_receiver,
+        download_sender.clone(),
+        message_sender,
+        cancel.clone(),
+        1,
+    );
+
+    download_sender
+        .send(download.clone())
+        .await
+        .expect("enqueue download");
+
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Active(_)
+    ));
+
+    wait_for_fixture_phase(&fixture_state, 1).await;
+    download.pause();
+    wait_for_paused(&download).await;
+    download.resume();
+
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Active(_)
+    ));
+
+    wait_for_fixture_phase(&fixture_state, 3).await;
+    download.pause();
+    wait_for_paused(&download).await;
+    download.resume();
+
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Active(_)
+    ));
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Inactive(_)
+    ));
+
+    let full_path = download.file_path.join(&download.node.name);
+    let contents = tokio::fs::read(&full_path)
+        .await
+        .expect("read completed file");
+    assert_eq!(contents, expected_plain);
+    assert!(
+        fixture_state.saw_non_zero_range.load(Ordering::SeqCst),
+        "expected resumed GET request with non-zero Range offset"
+    );
+
+    cancel.cancel();
+    for worker in workers {
+        worker.await.expect("worker join").expect("worker result");
+    }
+
+    fixture_shutdown.cancel();
+    timeout(Duration::from_secs(2), fixture_task)
+        .await
+        .expect("fixture task join timeout")
+        .expect("fixture task join failure");
 }
 
 #[tokio::test]


### PR DESCRIPTION
- refactors worker code into a folder module
- improves the pause/resume logic
- decouples runner from mega client
- adds integration tests covering pause, resume, cancel, happy cases, and previous racy cases
- improves handling of the rename file error case
- adds code quality github actions workflow