### PR TITLE
Add latest version update checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,6 +1417,7 @@ dependencies = [
  "num-traits",
  "regex",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "simple-logging",
@@ -1424,6 +1425,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "url",
+ "webbrowser",
 ]
 
 [[package]]
@@ -4960,6 +4962,22 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webbrowser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+dependencies = [
+ "core-foundation 0.10.1",
+ "jni 0.22.4",
+ "log",
+ "ndk-context",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "url",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,16 +24,18 @@ native-dialog = { version = "0.9", optional = true }
 num-traits = "0.2"
 regex = "1"
 reqwest = { version = "0.13", default-features = false, features = ["socks", "json", "stream", "rustls"] }
+semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 simple-logging = "2"
 tokio = { version = "1", default-features = false, features = ["sync", "fs", "io-util", "macros", "rt-multi-thread", "time"] }
 tokio-util = "0.7"
 url = { version = "2", features = ["serde"] }
+webbrowser = { version = "1", optional = true }
 
 [features]
 default = ["gui"]
-gui = ["dep:iced", "dep:native-dialog"]
+gui = ["dep:iced", "dep:native-dialog", "dep:webbrowser"]
 
 [profile.release]
 opt-level = 3

--- a/docs/plans/2026-06-07-001-feat-latest-version-update-check-plan.md
+++ b/docs/plans/2026-06-07-001-feat-latest-version-update-check-plan.md
@@ -1,0 +1,392 @@
+---
+title: "feat: Latest version/update check"
+type: feat
+status: active
+created: 2026-06-07
+source: https://github.com/chanderlud/giga-grabber/issues/26
+issue: 26
+depth: standard
+---
+
+# feat: Latest version/update check
+
+## Problem Frame
+
+Giga Grabber currently has no in-app way to tell users when a newer release is available. Issue #26 asks for a GUI update check that compares the locally installed Cargo package version with the latest GitHub release tag, informs the user when a newer version exists, links to the release page, and lets users turn automatic checks off or run a manual check from Settings.
+
+The app is a Rust iced GUI with a CLI fallback. This plan targets GUI behavior only. The CLI should not gain update-check behavior unless implementation discovers that a shared module cannot be cleanly isolated from CLI builds.
+
+---
+
+## Requirements Trace
+
+- R1. Check the latest GitHub tag with the existing `reqwest` HTTP client dependency.
+- R2. Compare the latest GitHub tag against the local installed Cargo package version from `Cargo.toml`, currently `1.3.2`.
+- R3. Notify the GUI user with a modal, dialog, or toast when a newer version is available.
+- R4. Include a link to the latest release page in the notification path.
+- R5. Add a Settings option to disable automatic update checks.
+- R6. Add a Settings control for a manual update check.
+- R7. Keep existing `config.json` files valid by using serde defaults for the new config field only.
+- R8. Do not add auto-download or self-update behavior.
+- R9. Do not add CLI update-check behavior unless shared code makes it unavoidable.
+
+---
+
+## Local Context
+
+- `Cargo.toml` declares package version `1.3.2`, uses Rust edition 2024, enables GUI by default, and already includes `reqwest = "0.13"` with `json`, `stream`, `socks`, and `rustls` features.
+- `src/config.rs` owns `Config`, default values, `config.json` load/save, normalization, and validation. Existing config files are deserialized through serde, so adding a persisted flag needs a serde default.
+- `src/screens/settings.rs` renders Settings, owns editable config state, defines `SettingsMessage`, and returns `settings::Action` values to the app.
+- `src/app.rs` owns app state, app startup, route/view selection, async iced `Task` orchestration, and the existing `error_modal` state.
+- `src/helpers.rs` defines the GUI `Message`, `Route`, `mega_builder`, and `runner_worker` patterns that app-level work should follow.
+- `src/components/error_modal.rs` is the existing modal pattern. It currently supports a message and an Ok button, with no release-link action.
+- CodeGraph is not initialized for this repo, so planning context came from direct file reads.
+- `node_modules/` exists as an untracked local directory and must not be committed or included in implementation artifacts.
+
+---
+
+## Scope Boundaries
+
+### In Scope
+
+- GUI update-check domain logic and HTTP client behavior.
+- Persisted opt-out setting for automatic checks.
+- Startup automatic check when enabled.
+- Manual check from Settings regardless of whether automatic checks are disabled.
+- User-visible notification when a newer version exists, including a path to open the latest release page.
+- User-visible feedback for manual checks when the app is current or the check fails.
+- Focused tests and verification guidance for the new domain logic, config behavior, app orchestration, and settings interactions.
+
+### Out of Scope
+
+- Auto-download, self-update, installer launch, or replacing the running binary.
+- CLI update checks, CLI flags, or CLI notifications unless unavoidable because shared compile-time version code requires minimal exposure.
+- Speculative compatibility behavior beyond serde defaults needed for existing `config.json` files.
+- Broad redesign of modals, Settings layout, or app navigation.
+- Dependency upgrades beyond what implementation proves necessary for this feature.
+
+### Deferred to Follow-Up Work
+
+- A richer toast system if the current modal/dialog path proves too limited for polished notifications.
+- Release-note preview content inside the app.
+
+---
+
+## Key Technical Decisions
+
+1. Add a small update-check module instead of embedding GitHub HTTP parsing in `src/app.rs`. This keeps version parsing, GitHub response handling, and comparison behavior testable without starting the GUI.
+2. Use `env!("CARGO_PKG_VERSION")` or `CARGO_PKG_VERSION` at compile time for the local app version instead of reading `Cargo.toml` at runtime. The package version remains the source for the installed binary, while runtime file reads would be brittle after installation.
+3. Represent the user notification as app state rather than reusing `error_modal: Option<String>` directly. Update availability is not an error, and the release link requires an action beyond closing the modal.
+4. Store the settings flag as a positive boolean such as `check_for_updates` defaulting to `true`. This matches the requirement to allow disabling checks while preserving automatic checks for existing users after adding the field.
+
+---
+
+## High-Level Technical Design
+
+This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant Config
+    participant UpdateCheck
+    participant GitHub
+    participant User
+
+    App->>Config: load config.json
+    App->>App: if check_for_updates is true, start async Task
+    App->>UpdateCheck: check current version against latest tag
+    UpdateCheck->>GitHub: fetch latest release or latest tag metadata
+    GitHub-->>UpdateCheck: latest tag and release URL
+    UpdateCheck-->>App: update available, current, or error
+    App-->>User: show update notification or manual-check feedback
+```
+
+---
+
+## Implementation Units
+
+### U1. Update-Check Domain and GitHub Client
+
+**Goal:** Add a testable update-check domain module that fetches the latest GitHub release/tag metadata with `reqwest`, parses the tag into a comparable version, compares it with the local Cargo package version, and returns an outcome the GUI can render.
+
+**Requirements:** R1, R2, R3, R4, R8, R9
+
+**Dependencies:** None
+
+**Files:**
+
+- `src/update_check.rs`
+- `src/main.rs`
+- `Cargo.toml`
+- `src/update_check.rs` test module
+
+**Approach:**
+
+- Define a small result shape for `Available`, `Current`, and `Failed` outcomes. The available outcome should include the latest version/tag and the latest release URL.
+- Use the existing `reqwest` dependency. Prefer a passed-in or locally built `reqwest::Client` so the module can be tested without coupling to the Mega client.
+- Query the GitHub endpoint that gives enough data for the latest release page link. If the issue truly requires tags rather than releases, still provide a deterministic link to the release page for the resolved tag.
+- Normalize tags that include a leading `v` before comparison.
+- Compare semantic versions against the local compile-time Cargo package version. Keep pre-release behavior simple and explicit in tests.
+- Gate the module for GUI use in `src/main.rs` so CLI-only builds do not gain update-check behavior.
+
+**Patterns to Follow:**
+
+- `src/helpers.rs` builds `reqwest::Client` through a narrow helper and returns typed errors through existing Rust result patterns.
+- `src/config.rs` keeps small domain helpers close to their related state and tests private behavior through module tests.
+
+**Test Scenarios:**
+
+- In `src/update_check.rs` test module, given local version `1.3.2` and latest tag `v1.3.3`, checking returns `Available` with version `1.3.3` and the release URL.
+- In `src/update_check.rs` test module, given local version `1.3.2` and latest tag `1.3.2`, checking returns `Current`.
+- In `src/update_check.rs` test module, given local version `1.3.2` and latest tag `v1.2.9`, checking returns `Current` rather than downgrading.
+- In `src/update_check.rs` test module, given a malformed tag, parsing returns a failure outcome or error that the app can display for manual checks.
+- In `src/update_check.rs` test module, given GitHub metadata with a tag and release HTML URL, the release URL is preserved exactly for the GUI action.
+
+**Verification:**
+
+- The update-check module can be exercised without launching iced.
+- Version comparison does not depend on reading `Cargo.toml` at runtime.
+- GitHub response parsing keeps enough data for the notification link.
+
+### U2. Config Persistence Flag
+
+**Goal:** Persist whether automatic update checks are enabled while keeping existing `config.json` files valid.
+
+**Requirements:** R5, R7
+
+**Dependencies:** None
+
+**Files:**
+
+- `src/config.rs`
+- `src/config.rs` test module
+
+**Approach:**
+
+- Add a `check_for_updates` boolean to `Config` with a default of `true`.
+- Use serde default handling on the new field so existing `config.json` files that lack it still load.
+- Include the field in `Default` and saved config output.
+- Do not add migration formats, legacy aliases, or extra compatibility branches beyond the serde default.
+
+**Patterns to Follow:**
+
+- `src/config.rs` already centralizes defaulting, normalization, validation, and save/load behavior.
+- Existing `Config::new()` fallback behavior should remain unchanged for invalid config files.
+
+**Test Scenarios:**
+
+- In `src/config.rs` test module, deserializing a config JSON object without `check_for_updates` yields `check_for_updates == true`.
+- In `src/config.rs` test module, deserializing a config JSON object with `check_for_updates: false` preserves `false`.
+- In `src/config.rs` test module, serializing `Config::default()` includes `check_for_updates: true`.
+- In `src/config.rs` test module, validation behavior for proxy settings is unchanged when the update-check flag is present.
+
+**Verification:**
+
+- Existing config files without the new field still load.
+- Saving settings writes the flag into `config.json`.
+
+### U3. App Orchestration for Startup and Manual Checks
+
+**Goal:** Wire update checks into `App` startup and manual Settings actions using iced `Task` without blocking the UI.
+
+**Requirements:** R1, R2, R3, R5, R6, R9
+
+**Dependencies:** U1, U2
+
+**Files:**
+
+- `src/app.rs`
+- `src/helpers.rs`
+- `src/screens/settings.rs`
+- `src/app.rs` test module, if app update logic is unit-testable in place
+
+**Approach:**
+
+- Add app-level messages for starting and completing update checks. Keep manual and automatic checks distinguishable so completion feedback can differ.
+- On startup, return an iced `Task` from `App::new` only when `settings.config.check_for_updates` is true.
+- Let Settings emit an action for manual check. `App::update` should convert that action into an async iced `Task`.
+- Avoid duplicate user notifications if an automatic check is already running and the user requests a manual check. A simple in-flight flag is enough if needed.
+- Automatic check failures should not show a scary error modal on startup. Manual check failures should give clear user feedback because the user requested the action.
+- Keep all orchestration inside GUI-gated code paths.
+
+**Patterns to Follow:**
+
+- `src/app.rs` already maps screen actions into iced `Task` values in the `Import` and `Settings` branches.
+- `src/helpers.rs` is the central place for the GUI `Message` enum, so new app messages should fit that pattern.
+
+**Test Scenarios:**
+
+- In `src/app.rs` test module, when config has `check_for_updates == true`, startup schedules an update-check task or reaches the app state that causes one to be scheduled.
+- In `src/app.rs` test module, when config has `check_for_updates == false`, startup does not schedule an automatic update-check task.
+- In `src/app.rs` test module, when Settings emits a manual-check action, `App::update` starts an update-check task even if automatic checks are disabled.
+- In `src/app.rs` test module, an automatic check failure leaves the app usable and does not replace an existing unrelated error modal.
+- In `src/app.rs` test module, a manual check failure produces user-visible feedback.
+
+**Verification:**
+
+- Startup remains non-blocking.
+- Manual checks are reachable from Settings.
+- CLI execution paths are not changed except for shared module compilation.
+
+### U4. User Notification Modal and Release Link
+
+**Goal:** Show update availability in the GUI with a clear notification and a release link action.
+
+**Requirements:** R3, R4, R8
+
+**Dependencies:** U1, U3
+
+**Files:**
+
+- `src/app.rs`
+- `src/components/error_modal.rs`
+- `src/components/update_modal.rs`, if a separate modal is cleaner than expanding `error_modal`
+- `src/helpers.rs`
+- `src/components/update_modal.rs` test module, if a new component is added
+
+**Approach:**
+
+- Prefer a dedicated update notification state and component if release-link actions would make `error_modal` misleading or overloaded.
+- The notification should show the current version, latest version, and a clear action to open the latest release page.
+- Closing the notification should not disable future checks. The Settings flag owns that preference.
+- Opening the link should use an appropriate browser-opening mechanism available to the GUI build. If no current dependency supports opening URLs, the fallback should be to show or copy the URL visibly, not to add auto-update behavior.
+- Manual `Current` feedback can reuse the same notification family or a simpler modal as long as it is clear and dismissible.
+
+**Patterns to Follow:**
+
+- `src/components/error_modal.rs` shows how the app layers modal content over the active route.
+- `src/app.rs::view` owns the final modal layering decision.
+
+**Test Scenarios:**
+
+- In `src/app.rs` or `src/components/update_modal.rs` test module, completing a check with `Available` stores notification state with latest version and release URL.
+- In `src/app.rs` or `src/components/update_modal.rs` test module, dismissing the notification clears only update notification state.
+- In `src/app.rs` or `src/components/update_modal.rs` test module, activating the release action uses the available release URL from the update-check result.
+- In `src/app.rs` or `src/components/update_modal.rs` test module, completing a manual check with `Current` produces a dismissible current-version message.
+
+**Verification:**
+
+- A newer release produces a visible GUI notification.
+- The latest release page link is available from that notification path.
+- No auto-download or self-update action exists.
+
+### U5. Settings UI Controls
+
+**Goal:** Add Settings controls for disabling automatic checks and manually checking for updates.
+
+**Requirements:** R5, R6
+
+**Dependencies:** U2, U3
+
+**Files:**
+
+- `src/screens/settings.rs`
+- `src/config.rs`
+- `src/screens/settings.rs` test module
+
+**Approach:**
+
+- Add a `SettingsMessage` variant for toggling automatic update checks.
+- Add a `SettingsMessage` variant and `settings::Action` for manual update check requests.
+- Place the new controls near other general settings, separate from proxy-specific controls.
+- Toggling the automatic check flag should mark settings as needing save, or should save through the same explicit Save flow used by other settings. Pick the path that best matches current Settings behavior.
+- Manual check should not require saving the config first. It reads the current app version and remote release state, not persisted Settings values.
+
+**Patterns to Follow:**
+
+- `src/screens/settings.rs` uses small message variants, mutates `self.config`, and returns screen actions for app-level effects.
+- Existing Save, Reset, and Apply controls provide the layout style for the new manual check button.
+
+**Test Scenarios:**
+
+- In `src/screens/settings.rs` test module, toggling update checks from true to false updates `settings.config.check_for_updates`.
+- In `src/screens/settings.rs` test module, toggling update checks marks the config as changed according to the chosen Settings save pattern.
+- In `src/screens/settings.rs` test module, pressing the manual check button returns the app-level action for a manual update check.
+- In `src/screens/settings.rs` test module, resetting Settings restores `check_for_updates == true` through `Config::default()`.
+
+**Verification:**
+
+- Users can disable automatic update checks in Settings.
+- Users can run a manual check from Settings.
+- The controls match existing iced Settings layout and do not affect proxy or download settings.
+
+### U6. Tests and Verification Coverage
+
+**Goal:** Add focused coverage and implementation verification so the update-check feature is safe to ship.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7, R8, R9
+
+**Dependencies:** U1, U2, U3, U4, U5
+
+**Files:**
+
+- `src/update_check.rs` test module
+- `src/config.rs` test module
+- `src/app.rs` test module, if app update logic is testable without launching iced
+- `src/screens/settings.rs` test module
+- `src/components/update_modal.rs` test module, if a new component is added
+
+**Approach:**
+
+- Prefer module-level unit tests because there is no existing `tests/` directory and much of the relevant code is `pub(crate)` or private.
+- Use dependency injection or small pure helpers for version comparison and response parsing so tests do not require live GitHub access.
+- For GUI orchestration that cannot be cleanly unit tested, document manual verification as part of implementation handoff rather than forcing brittle UI tests into this plan.
+- Keep network-dependent behavior out of automated tests.
+
+**Patterns to Follow:**
+
+- Current code keeps behavior in small methods that can be tested near the module when needed.
+- Existing `tempfile` dev dependency can support config persistence tests without touching the developer's real `config.json`.
+
+**Test Scenarios:**
+
+- Automated tests cover version parsing, comparison, GitHub metadata parsing, config defaulting, Settings toggle behavior, manual-check action emission, and app-level result handling.
+- Manual verification covers app startup with automatic checks enabled, startup with checks disabled, manual check from Settings, update available notification, current-version feedback, failure feedback, and release-link behavior.
+- Regression verification confirms the CLI still runs without new update-check prompts or network calls.
+
+**Verification:**
+
+- The implementer can prove behavior without relying on live GitHub in automated tests.
+- Manual GUI verification exercises the feature through the same surfaces a user sees.
+- `node_modules/` remains untracked local noise and is not included in any change set.
+
+---
+
+## System-Wide Impact
+
+- **End users:** GUI users get release awareness and can opt out of automatic checks.
+- **Developers:** A new update-check module adds a small GitHub-facing client surface that needs tests independent of live network access.
+- **Operations and releases:** Release tags need to remain compatible with the comparison rules, especially around a leading `v` prefix.
+- **CLI users:** CLI behavior should remain unchanged.
+
+---
+
+## Risks and Mitigations
+
+- **GitHub API shape or rate limits:** Keep parsing narrow, handle failures gracefully, and avoid startup error noise for automatic checks.
+- **Version comparison mistakes:** Cover leading `v`, equal versions, older tags, newer tags, and malformed tags in unit tests.
+- **Existing config breakage:** Use serde defaulting for only the new `check_for_updates` field and test old config JSON.
+- **Modal overload:** Prefer a dedicated update modal if adding link actions would make `error_modal` unclear.
+- **Accidental CLI behavior:** Keep startup orchestration in GUI app code and verify CLI paths stay quiet.
+
+---
+
+## Deferred Implementation Notes
+
+- The exact GitHub endpoint should be selected during implementation based on which response best provides both the latest tag and release page URL. The result contract in U1 should stay stable either way.
+- The exact browser-opening mechanism should be chosen during implementation based on current dependencies and platform support. If adding a small dependency is necessary, keep it scoped to GUI behavior.
+- The exact app test seams may need small helper extraction because iced `Task` values are not always directly inspectable.
+
+---
+
+## Acceptance Checklist
+
+- A newer GitHub tag than the local Cargo package version causes a GUI notification with the latest release link.
+- An equal or older tag does not show an automatic update-available notification.
+- Manual check from Settings gives user-visible feedback for available, current, and failure outcomes.
+- Users can disable automatic update checks in Settings, save that preference, and keep manual checks available.
+- Existing `config.json` files without the new setting continue to load.
+- No auto-download or self-update behavior is added.
+- CLI behavior remains unchanged unless implementation proves a minimal shared-code compile change unavoidable.
+- The untracked `node_modules/` directory is not committed.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,16 +1,17 @@
-use crate::components::{error_modal, nav_sidebar};
+use crate::components::{error_modal, nav_sidebar, update_modal};
 use crate::config::Config;
 use crate::helpers::*;
 use crate::mega_client::MegaClient;
 use crate::resources::*;
 use crate::screens::*;
+use crate::update_check;
 use crate::{Download, MegaFile, RunnerMessage, spawn_workers};
 use futures::future::join_all;
 use iced::font::{Family, Weight};
 use iced::time::every;
 use iced::widget::{Row, container, text};
 use iced::{Element, Font, Length, Subscription, Task, Theme};
-use log::error;
+use log::{error, warn};
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
@@ -36,11 +37,13 @@ pub(crate) struct App {
     file_handles: HashSet<String>,
     route: Route,
     error_modal: Option<String>,
+    update_notification: Option<update_modal::Notification>,
+    update_check_in_flight: bool,
+    manual_update_feedback_pending: bool,
 }
 
 impl App {
     fn new() -> (Self, Task<Message>) {
-        let (download_sender, download_receiver) = kanal::unbounded();
         // load config from disk, falling back to a default config if needed
         let (mut config, mut error_modal) = Config::new();
         // build the mega client, falling back to default config if needed
@@ -54,23 +57,37 @@ impl App {
             }
         };
 
-        (
-            Self {
-                settings: Settings::new(config),
-                import: Import::new(),
-                choose_files: None,
-                home: Home::new(),
-                mega,
-                worker: None,
-                runner_sender: None,
-                download_sender,
-                download_receiver: download_receiver.to_async(),
-                file_handles: HashSet::new(),
-                route: Route::Home,
-                error_modal,
-            },
-            Task::none(),
-        )
+        let start_update_check = startup_update_check_enabled(&config);
+        let mut app = Self::from_parts(config, mega, error_modal);
+        let task = if start_update_check {
+            app.start_update_check(UpdateCheckKind::Automatic)
+        } else {
+            Task::none()
+        };
+
+        (app, task)
+    }
+
+    fn from_parts(config: Config, mega: MegaClient, error_modal: Option<String>) -> Self {
+        let (download_sender, download_receiver) = kanal::unbounded();
+
+        Self {
+            settings: Settings::new(config),
+            import: Import::new(),
+            choose_files: None,
+            home: Home::new(),
+            mega,
+            worker: None,
+            runner_sender: None,
+            download_sender,
+            download_receiver: download_receiver.to_async(),
+            file_handles: HashSet::new(),
+            route: Route::Home,
+            error_modal,
+            update_notification: None,
+            update_check_in_flight: false,
+            manual_update_feedback_pending: false,
+        }
     }
 
     fn title(&self) -> String {
@@ -211,6 +228,19 @@ impl App {
                 self.error_modal = None;
                 Task::none()
             }
+            Message::CloseUpdateNotification => {
+                self.update_notification = None;
+                Task::none()
+            }
+            Message::OpenUpdateRelease => {
+                if let Some(url) = self.update_release_url() {
+                    if let Err(error) = webbrowser::open(url) {
+                        self.error_modal = Some(format!("Failed to open release page: {error}"));
+                    }
+                }
+
+                Task::none()
+            }
             Message::Settings(msg) => {
                 use crate::screens::settings::Action;
                 match self.settings.update(msg) {
@@ -247,7 +277,12 @@ impl App {
                         self.error_modal = Some(error);
                         Task::none()
                     }
+                    Action::CheckForUpdates => self.start_update_check(UpdateCheckKind::Manual),
                 }
+            }
+            Message::UpdateCheckFinished(kind, outcome) => {
+                self.handle_update_check_finished(kind, outcome);
+                Task::none()
             }
             Message::ClearFiles => {
                 self.file_handles.clear(); // clear file handles tracking
@@ -293,10 +328,19 @@ impl App {
         .width(Length::Fill)
         .height(Length::Fill);
 
-        if let Some(error_message) = &self.error_modal {
+        let content: Element<'_, Message> = if let Some(error_message) = &self.error_modal {
             error_modal::error_modal(error_message, body.into()).map(|_| Message::CloseModal)
         } else {
             body.into()
+        };
+
+        if let Some(notification) = &self.update_notification {
+            update_modal::update_modal(notification, content).map(|message| match message {
+                update_modal::Message::Dismiss => Message::CloseUpdateNotification,
+                update_modal::Message::OpenRelease => Message::OpenUpdateRelease,
+            })
+        } else {
+            content
         }
     }
 
@@ -315,6 +359,62 @@ impl App {
 
         // run all subscriptions in parallel
         Subscription::batch(vec![runner_subscription, refresh])
+    }
+
+    fn start_update_check(&mut self, kind: UpdateCheckKind) -> Task<Message> {
+        if self.update_check_in_flight {
+            if kind == UpdateCheckKind::Manual {
+                self.manual_update_feedback_pending = true;
+                self.update_notification = Some(update_modal::Notification::InProgress);
+            }
+            return Task::none();
+        }
+
+        self.update_check_in_flight = true;
+        Task::perform(update_check::check_latest_release(), move |outcome| {
+            Message::UpdateCheckFinished(kind, outcome)
+        })
+    }
+
+    fn handle_update_check_finished(
+        &mut self,
+        kind: UpdateCheckKind,
+        outcome: update_check::Outcome,
+    ) {
+        self.update_check_in_flight = false;
+        let should_show_feedback =
+            kind == UpdateCheckKind::Manual || self.manual_update_feedback_pending;
+        self.manual_update_feedback_pending = false;
+
+        match outcome {
+            update_check::Outcome::Available(info) => {
+                self.update_notification = Some(update_modal::Notification::Available(info));
+            }
+            update_check::Outcome::Current {
+                current_version,
+                latest_version,
+            } => {
+                if should_show_feedback {
+                    self.update_notification = Some(update_modal::Notification::Current {
+                        current_version,
+                        latest_version,
+                    });
+                }
+            }
+            update_check::Outcome::Failed(message) => {
+                if should_show_feedback {
+                    self.update_notification = Some(update_modal::Notification::Failed(message));
+                } else {
+                    warn!("automatic update check failed: {message}");
+                }
+            }
+        }
+    }
+
+    fn update_release_url(&self) -> Option<&str> {
+        self.update_notification
+            .as_ref()
+            .and_then(update_modal::Notification::release_url)
     }
 
     fn start_workers(&self, workers: usize) -> WorkerState {
@@ -390,6 +490,10 @@ impl App {
     }
 }
 
+fn startup_update_check_enabled(config: &Config) -> bool {
+    config.check_for_updates
+}
+
 /// builds the iced app
 pub(crate) fn build_app() -> iced::Application<impl iced::Program<Message = Message, Theme = Theme>>
 {
@@ -401,4 +505,131 @@ pub(crate) fn build_app() -> iced::Application<impl iced::Program<Message = Mess
         .font(CABIN_REGULAR)
         .font(INCONSOLATA_MEDIUM)
         .default_font(Font::with_name("Cabin"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::update_check::{Outcome, UpdateInfo};
+
+    fn test_app(config: Config) -> App {
+        let mega = mega_builder(&config).expect("default test config should build client");
+        App::from_parts(config, mega, None)
+    }
+
+    #[test]
+    fn startup_check_follows_config_flag() {
+        let mut config = Config::default();
+        assert!(startup_update_check_enabled(&config));
+
+        config.check_for_updates = false;
+        assert!(!startup_update_check_enabled(&config));
+    }
+
+    #[test]
+    fn manual_check_starts_even_when_auto_checks_are_disabled() {
+        let mut config = Config::default();
+        config.check_for_updates = false;
+        let mut app = test_app(config);
+
+        let _task = app.start_update_check(UpdateCheckKind::Manual);
+
+        assert!(app.update_check_in_flight);
+    }
+
+    #[test]
+    fn manual_request_during_automatic_check_gets_completion_feedback() {
+        let mut app = test_app(Config::default());
+        app.update_check_in_flight = true;
+
+        let _task = app.start_update_check(UpdateCheckKind::Manual);
+        assert!(app.manual_update_feedback_pending);
+        assert_eq!(
+            app.update_notification,
+            Some(update_modal::Notification::InProgress)
+        );
+
+        app.handle_update_check_finished(
+            UpdateCheckKind::Automatic,
+            Outcome::Current {
+                current_version: "1.3.2".to_string(),
+                latest_version: "1.3.2".to_string(),
+            },
+        );
+
+        assert!(!app.manual_update_feedback_pending);
+        assert_eq!(
+            app.update_notification,
+            Some(update_modal::Notification::Current {
+                current_version: "1.3.2".to_string(),
+                latest_version: "1.3.2".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn automatic_check_failure_does_not_replace_error_modal() {
+        let mut app = test_app(Config::default());
+        app.error_modal = Some("keep this error".to_string());
+        app.update_check_in_flight = true;
+
+        app.handle_update_check_finished(
+            UpdateCheckKind::Automatic,
+            Outcome::Failed("network unavailable".to_string()),
+        );
+
+        assert_eq!(app.error_modal, Some("keep this error".to_string()));
+        assert_eq!(app.update_notification, None);
+        assert!(!app.update_check_in_flight);
+    }
+
+    #[test]
+    fn manual_check_failure_produces_visible_notification() {
+        let mut app = test_app(Config::default());
+
+        app.handle_update_check_finished(
+            UpdateCheckKind::Manual,
+            Outcome::Failed("network unavailable".to_string()),
+        );
+
+        assert_eq!(
+            app.update_notification,
+            Some(update_modal::Notification::Failed(
+                "network unavailable".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn available_update_stores_release_url_for_action() {
+        let mut app = test_app(Config::default());
+
+        app.handle_update_check_finished(
+            UpdateCheckKind::Automatic,
+            Outcome::Available(UpdateInfo {
+                current_version: "1.3.2".to_string(),
+                latest_version: "1.3.3".to_string(),
+                tag: "v1.3.3".to_string(),
+                release_url: "https://github.com/chanderlud/giga-grabber/releases/tag/v1.3.3"
+                    .to_string(),
+            }),
+        );
+
+        assert_eq!(
+            app.update_release_url(),
+            Some("https://github.com/chanderlud/giga-grabber/releases/tag/v1.3.3")
+        );
+    }
+
+    #[test]
+    fn dismissing_update_notification_clears_only_update_state() {
+        let mut app = test_app(Config::default());
+        app.error_modal = Some("keep this error".to_string());
+        app.update_notification = Some(update_modal::Notification::InProgress);
+
+        let _task = app.update(Message::CloseUpdateNotification);
+
+        assert_eq!(app.error_modal, Some("keep this error".to_string()));
+        assert_eq!(app.update_notification, None);
+    }
 }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod download_item;
 pub(crate) mod error_modal;
 pub(crate) mod nav_sidebar;
+pub(crate) mod update_modal;

--- a/src/components/update_modal.rs
+++ b/src/components/update_modal.rs
@@ -1,0 +1,173 @@
+use crate::styles;
+use crate::update_check::UpdateInfo;
+use iced::alignment::{Horizontal, Vertical};
+use iced::widget::{
+    Column, Row, button, center, container, mouse_area, opaque, space, stack, text,
+};
+use iced::{Color, Element, Length, border};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Notification {
+    Available(UpdateInfo),
+    Current {
+        current_version: String,
+        latest_version: String,
+    },
+    Failed(String),
+    InProgress,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum Message {
+    Dismiss,
+    OpenRelease,
+}
+
+impl Notification {
+    pub(crate) fn release_url(&self) -> Option<&str> {
+        match self {
+            Self::Available(info) => Some(&info.release_url),
+            Self::Current { .. } | Self::Failed(_) | Self::InProgress => None,
+        }
+    }
+}
+
+pub(crate) fn update_modal<'a, AppMessage: 'a>(
+    notification: &'a Notification,
+    content: Element<'a, AppMessage>,
+) -> Element<'a, Message> {
+    stack![
+        content.map(|_| Message::Dismiss),
+        opaque(
+            mouse_area(center(opaque(modal_content(notification))).style(|_theme| {
+                container::Style {
+                    background: Some(
+                        Color {
+                            a: 0.5,
+                            ..Color::BLACK
+                        }
+                        .into(),
+                    ),
+                    ..Default::default()
+                }
+            }))
+            .on_press(Message::Dismiss)
+        )
+    ]
+    .into()
+}
+
+fn modal_content(notification: &Notification) -> Element<'_, Message> {
+    let (title, body) = notification_copy(notification);
+    let mut actions = Row::new()
+        .spacing(5)
+        .push(space::horizontal().width(Length::Fill));
+
+    if matches!(notification, Notification::Available(_)) {
+        actions = actions.push(
+            button(" Release page ")
+                .style(styles::button::primary)
+                .on_press(Message::OpenRelease),
+        );
+    }
+
+    actions = actions.push(
+        button(" Ok ")
+            .style(styles::button::warning)
+            .on_press(Message::Dismiss),
+    );
+
+    container(
+        Column::new()
+            .spacing(8)
+            .push(
+                text(title)
+                    .size(20)
+                    .align_y(Vertical::Center)
+                    .align_x(Horizontal::Center)
+                    .width(Length::Fill),
+            )
+            .push(
+                text(body)
+                    .size(16)
+                    .align_y(Vertical::Center)
+                    .align_x(Horizontal::Center)
+                    .width(Length::Fill),
+            )
+            .push(actions),
+    )
+    .width(Length::Fixed(360_f32))
+    .padding(12)
+    .style(|theme| {
+        let palette = theme.extended_palette();
+
+        container::Style {
+            background: Some(palette.background.weak.color.into()),
+            text_color: Some(palette.background.weak.text),
+            border: border::rounded(8),
+            ..Default::default()
+        }
+    })
+    .into()
+}
+
+fn notification_copy(notification: &Notification) -> (&'static str, String) {
+    match notification {
+        Notification::Available(info) => (
+            "Update available",
+            format!(
+                "Giga Grabber {} is available. You are running {}.",
+                info.latest_version, info.current_version
+            ),
+        ),
+        Notification::Current {
+            current_version,
+            latest_version,
+        } => (
+            "You're up to date",
+            format!("Giga Grabber {current_version} is current. Latest release: {latest_version}."),
+        ),
+        Notification::Failed(message) => (
+            "Update check failed",
+            format!("Could not check for updates: {message}"),
+        ),
+        Notification::InProgress => (
+            "Update check in progress",
+            "An update check is already running.".to_string(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn available_notification_exposes_release_url() {
+        let notification = Notification::Available(UpdateInfo {
+            current_version: "1.3.2".to_string(),
+            latest_version: "1.3.3".to_string(),
+            tag: "v1.3.3".to_string(),
+            release_url: "https://github.com/chanderlud/giga-grabber/releases/tag/v1.3.3"
+                .to_string(),
+        });
+
+        assert_eq!(
+            notification.release_url(),
+            Some("https://github.com/chanderlud/giga-grabber/releases/tag/v1.3.3")
+        );
+    }
+
+    #[test]
+    fn non_available_notifications_do_not_expose_release_url() {
+        assert_eq!(Notification::InProgress.release_url(), None);
+        assert_eq!(
+            Notification::Current {
+                current_version: "1.3.2".to_string(),
+                latest_version: "1.3.2".to_string(),
+            }
+            .release_url(),
+            None
+        );
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,8 @@ pub(crate) struct Config {
     pub(crate) min_retry_delay: Duration,
     pub(crate) proxy_mode: ProxyMode,
     pub(crate) proxies: Vec<Url>,
+    #[serde(default = "default_check_for_updates")]
+    pub(crate) check_for_updates: bool,
 }
 
 // default options
@@ -85,6 +87,7 @@ impl Default for Config {
             min_retry_delay: Duration::from_secs(10),
             proxy_mode: ProxyMode::None,
             proxies: Vec::new(),
+            check_for_updates: default_check_for_updates(),
         }
     }
 }
@@ -326,4 +329,61 @@ fn save_default() -> Config {
         error!("Failed to save default config: {save_error}",);
     }
     config
+}
+
+fn default_check_for_updates() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_config_json() -> serde_json::Value {
+        serde_json::to_value(Config::default()).expect("default config should serialize")
+    }
+
+    #[test]
+    fn missing_update_check_flag_defaults_to_enabled() {
+        let mut value = default_config_json();
+        value
+            .as_object_mut()
+            .expect("config should serialize as object")
+            .remove("check_for_updates");
+
+        let config: Config = serde_json::from_value(value).expect("legacy config should load");
+        assert!(config.check_for_updates);
+    }
+
+    #[test]
+    fn explicit_disabled_update_check_flag_is_preserved() {
+        let mut value = default_config_json();
+        value["check_for_updates"] = serde_json::Value::Bool(false);
+
+        let config: Config = serde_json::from_value(value).expect("config should load");
+        assert!(!config.check_for_updates);
+    }
+
+    #[test]
+    fn default_config_serializes_update_check_flag() {
+        let value = default_config_json();
+        assert_eq!(value["check_for_updates"], serde_json::Value::Bool(true));
+    }
+
+    #[test]
+    fn proxy_validation_is_unchanged_when_update_check_flag_is_present() {
+        let mut config = Config {
+            proxy_mode: ProxyMode::Single,
+            proxies: vec![Url::parse("http://127.0.0.1:8080").expect("valid proxy URL")],
+            check_for_updates: false,
+            ..Config::default()
+        };
+        assert!(config.validate().is_ok());
+
+        config.proxies.clear();
+        assert_eq!(
+            config.validate(),
+            Err("proxy_mode is enabled but no proxies are configured".to_string())
+        );
+    }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,3 +1,4 @@
+use crate::ProxyMode;
 #[cfg(feature = "gui")]
 use crate::RunnerMessage;
 #[cfg(feature = "gui")]
@@ -6,7 +7,10 @@ use crate::config::Config;
 use crate::mega_client::MegaClient;
 #[cfg(feature = "gui")]
 use crate::screens::{ChooseFilesMessage, HomeMessage, ImportMessage, SettingsMessage};
-use crate::{ProxyMode, styles};
+#[cfg(feature = "gui")]
+use crate::styles;
+#[cfg(feature = "gui")]
+use crate::update_check;
 #[cfg(feature = "gui")]
 use iced::futures::Stream;
 #[cfg(feature = "gui")]
@@ -20,9 +24,11 @@ use iced::{Element, Length, Theme, stream};
 use reqwest::{Client, Proxy};
 #[cfg(feature = "gui")]
 use std::collections::HashMap;
+#[cfg(feature = "gui")]
 use std::time::Duration;
 #[cfg(feature = "gui")]
 use tokio::sync::mpsc::{Sender, channel};
+#[cfg(feature = "gui")]
 use tokio::time::{MissedTickBehavior, interval};
 #[cfg(feature = "gui")]
 use tokio_util::sync::CancellationToken;
@@ -51,6 +57,19 @@ pub(crate) enum Message {
     Settings(SettingsMessage),
     /// remove any loaded files
     ClearFiles,
+    /// update check completed
+    UpdateCheckFinished(UpdateCheckKind, update_check::Outcome),
+    /// close the update notification modal
+    CloseUpdateNotification,
+    /// open the latest release page from the update notification
+    OpenUpdateRelease,
+}
+
+#[cfg(feature = "gui")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UpdateCheckKind {
+    Automatic,
+    Manual,
 }
 
 #[cfg(feature = "gui")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,8 @@ mod resources;
 mod screens;
 #[cfg(feature = "gui")]
 mod styles;
+#[cfg(feature = "gui")]
+mod update_check;
 mod worker;
 
 type WorkerHandle = JoinHandle<anyhow::Result<()>>;

--- a/src/screens/settings.rs
+++ b/src/screens/settings.rs
@@ -6,7 +6,8 @@ use crate::resources::X_ICON;
 use crate::styles;
 use iced::alignment::{Horizontal, Vertical};
 use iced::widget::{
-    Column, Row, button, container, pick_list, scrollable, slider, space, svg, text, text_input,
+    Column, Row, button, checkbox, container, pick_list, scrollable, slider, space, svg, text,
+    text_input,
 };
 use iced::{Element, Length, Theme};
 use native_dialog::FileDialogBuilder;
@@ -36,6 +37,8 @@ pub(crate) enum Message {
     AddProxies,
     RemoveProxy(usize),
     RebuildMega,
+    ToggleUpdateChecks(bool),
+    CheckForUpdates,
 }
 
 pub(crate) enum Action {
@@ -43,6 +46,7 @@ pub(crate) enum Action {
     ConfigSaved,
     RebuildRequired(Config),
     ShowError(String),
+    CheckForUpdates,
 }
 
 impl Settings {
@@ -144,6 +148,11 @@ impl Settings {
                 self.config.theme = theme;
                 Action::None
             }
+            Message::ToggleUpdateChecks(check_for_updates) => {
+                self.config.check_for_updates = check_for_updates;
+                Action::None
+            }
+            Message::CheckForUpdates => Action::CheckForUpdates,
             Message::ProxyModeChanged(proxy_mode) => {
                 if proxy_mode == ProxyMode::Single {
                     self.config.proxies.truncate(1);
@@ -274,6 +283,8 @@ impl Settings {
                         ),
                 )
                 .push(space::vertical().height(Length::Fixed(10_f32)))
+                .push(self.update_check_controls())
+                .push(space::vertical().height(Length::Fixed(10_f32)))
                 .push(self.settings_picklist(
                     "Proxy Mode",
                     &ProxyMode::ALL[..],
@@ -302,6 +313,44 @@ impl Settings {
                 ),
         )
         .into()
+    }
+
+    fn update_check_controls(&self) -> Element<'_, Message> {
+        Column::new()
+            .spacing(5)
+            .push(
+                Row::new()
+                    .height(Length::Fixed(30_f32))
+                    .push(space::horizontal().width(Length::Fixed(8_f32)))
+                    .push(
+                        text("Check for updates on startup")
+                            .align_y(Vertical::Center)
+                            .height(Length::Fill),
+                    )
+                    .push(space::horizontal())
+                    .push(
+                        checkbox(self.config.check_for_updates)
+                            .on_toggle(Message::ToggleUpdateChecks)
+                            .style(checkbox::primary),
+                    ),
+            )
+            .push(
+                Row::new()
+                    .height(Length::Fixed(30_f32))
+                    .push(space::horizontal().width(Length::Fixed(8_f32)))
+                    .push(
+                        text("Updates")
+                            .align_y(Vertical::Center)
+                            .height(Length::Fill),
+                    )
+                    .push(space::horizontal())
+                    .push(
+                        button(" Check now ")
+                            .style(styles::button::primary)
+                            .on_press(Message::CheckForUpdates),
+                    ),
+            )
+            .into()
     }
 
     fn settings_slider<'a>(
@@ -431,5 +480,43 @@ impl Settings {
             .push(space::horizontal().width(Length::Fixed(8_f32)))
             .push(column)
             .into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn toggling_update_checks_updates_config_without_rebuild() {
+        let mut settings = Settings::new(Config::default());
+        assert!(settings.config.check_for_updates);
+
+        let action = settings.update(Message::ToggleUpdateChecks(false));
+
+        assert!(matches!(action, Action::None));
+        assert!(!settings.config.check_for_updates);
+        assert!(!settings.rebuild_available);
+    }
+
+    #[test]
+    fn manual_update_check_emits_app_action() {
+        let mut settings = Settings::new(Config::default());
+
+        let action = settings.update(Message::CheckForUpdates);
+
+        assert!(matches!(action, Action::CheckForUpdates));
+    }
+
+    #[test]
+    fn resetting_settings_restores_update_checks_enabled() {
+        let mut config = Config::default();
+        config.check_for_updates = false;
+        let mut settings = Settings::new(config);
+
+        let action = settings.update(Message::ResetConfig);
+
+        assert!(matches!(action, Action::None));
+        assert!(settings.config.check_for_updates);
     }
 }

--- a/src/update_check.rs
+++ b/src/update_check.rs
@@ -1,0 +1,233 @@
+use reqwest::Client;
+use semver::Version;
+use serde::Deserialize;
+use std::fmt::Display;
+
+const GITHUB_LATEST_RELEASE_URL: &str =
+    "https://api.github.com/repos/chanderlud/giga-grabber/releases/latest";
+const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
+pub(crate) const LOCAL_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Debug)]
+pub(crate) enum Error {
+    Http(reqwest::Error),
+    Version(semver::Error),
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(error: reqwest::Error) -> Self {
+        Self::Http(error)
+    }
+}
+
+impl From<semver::Error> for Error {
+    fn from(error: semver::Error) -> Self {
+        Self::Version(error)
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Http(error) => write!(f, "failed to fetch latest release: {error}"),
+            Self::Version(error) => write!(f, "failed to parse release version: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UpdateInfo {
+    pub(crate) current_version: String,
+    pub(crate) latest_version: String,
+    pub(crate) tag: String,
+    pub(crate) release_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Outcome {
+    Available(UpdateInfo),
+    Current {
+        current_version: String,
+        latest_version: String,
+    },
+    Failed(String),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GitHubRelease {
+    tag_name: String,
+    html_url: String,
+}
+
+pub(crate) async fn check_latest_release() -> Outcome {
+    match check_latest_release_with_client(&Client::new()).await {
+        Ok(outcome) => outcome,
+        Err(error) => Outcome::Failed(error.to_string()),
+    }
+}
+
+async fn check_latest_release_with_client(client: &Client) -> Result<Outcome, Error> {
+    let release = fetch_latest_release(client).await?;
+    outcome_from_release(LOCAL_VERSION, release)
+}
+
+async fn fetch_latest_release(client: &Client) -> Result<GitHubRelease, Error> {
+    let release = client
+        .get(GITHUB_LATEST_RELEASE_URL)
+        .header("User-Agent", USER_AGENT)
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<GitHubRelease>()
+        .await?;
+
+    Ok(release)
+}
+
+fn outcome_from_release(local_version: &str, release: GitHubRelease) -> Result<Outcome, Error> {
+    let current = parse_version(local_version)?;
+    let latest = parse_version(&release.tag_name)?;
+    let current_version = current.to_string();
+    let latest_version = latest.to_string();
+
+    if latest > current {
+        Ok(Outcome::Available(UpdateInfo {
+            current_version,
+            latest_version,
+            tag: release.tag_name,
+            release_url: release.html_url,
+        }))
+    } else {
+        Ok(Outcome::Current {
+            current_version,
+            latest_version,
+        })
+    }
+}
+
+fn parse_version(version: &str) -> Result<Version, semver::Error> {
+    let normalized = version
+        .trim()
+        .strip_prefix('v')
+        .or_else(|| version.trim().strip_prefix('V'))
+        .unwrap_or_else(|| version.trim());
+
+    Version::parse(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn release(tag_name: &str, html_url: &str) -> GitHubRelease {
+        GitHubRelease {
+            tag_name: tag_name.to_string(),
+            html_url: html_url.to_string(),
+        }
+    }
+
+    #[test]
+    fn newer_leading_v_tag_returns_available_with_release_url() {
+        let outcome = outcome_from_release(
+            "1.3.2",
+            release(
+                "v1.3.3",
+                "https://github.com/chanderlud/giga-grabber/releases/tag/v1.3.3",
+            ),
+        )
+        .expect("valid release should compare");
+
+        assert_eq!(
+            outcome,
+            Outcome::Available(UpdateInfo {
+                current_version: "1.3.2".to_string(),
+                latest_version: "1.3.3".to_string(),
+                tag: "v1.3.3".to_string(),
+                release_url: "https://github.com/chanderlud/giga-grabber/releases/tag/v1.3.3"
+                    .to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn equal_tag_returns_current() {
+        let outcome = outcome_from_release(
+            "1.3.2",
+            release(
+                "1.3.2",
+                "https://github.com/chanderlud/giga-grabber/releases/tag/1.3.2",
+            ),
+        )
+        .expect("valid release should compare");
+
+        assert_eq!(
+            outcome,
+            Outcome::Current {
+                current_version: "1.3.2".to_string(),
+                latest_version: "1.3.2".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn older_tag_returns_current() {
+        let outcome = outcome_from_release(
+            "1.3.2",
+            release(
+                "v1.2.9",
+                "https://github.com/chanderlud/giga-grabber/releases/tag/v1.2.9",
+            ),
+        )
+        .expect("valid release should compare");
+
+        assert_eq!(
+            outcome,
+            Outcome::Current {
+                current_version: "1.3.2".to_string(),
+                latest_version: "1.2.9".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn malformed_tag_returns_error() {
+        let error = outcome_from_release(
+            "1.3.2",
+            release("release-latest", "https://example.com/release"),
+        )
+        .expect_err("malformed tag should fail");
+
+        assert!(matches!(error, Error::Version(_)));
+    }
+
+    #[test]
+    fn github_release_json_preserves_release_url() {
+        let json = r#"{
+            "tag_name": "v1.4.0",
+            "html_url": "https://github.com/chanderlud/giga-grabber/releases/tag/v1.4.0"
+        }"#;
+
+        let release: GitHubRelease = serde_json::from_str(json).expect("json should parse");
+        assert_eq!(release.tag_name, "v1.4.0");
+        assert_eq!(
+            release.html_url,
+            "https://github.com/chanderlud/giga-grabber/releases/tag/v1.4.0"
+        );
+    }
+
+    #[test]
+    fn prerelease_comparison_uses_semver_ordering() {
+        let outcome = outcome_from_release(
+            "1.3.2",
+            release(
+                "v1.3.3-beta.1",
+                "https://github.com/chanderlud/giga-grabber/releases/tag/v1.3.3-beta.1",
+            ),
+        )
+        .expect("valid prerelease should compare");
+
+        assert!(matches!(outcome, Outcome::Available(_)));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a reqwest-based GitHub latest-release check compared against the compiled Cargo package version
- Adds startup update checks with a persisted Settings opt-out and a manual "Check now" action
- Adds update/current/failure modals with a release-page action

Closes #26

## Verification
- cargo fmt --check
- cargo check
- cargo test
- cargo check --no-default-features
- cargo test --no-default-features
- cargo run --no-default-features -- --help
- GUI smoke launch stayed running until timeout
- LSP diagnostics clean on changed Rust files
- ce-code-review mode:autofix found no safe_auto fixes or residual actionable work