### PR TITLE
Handle MEGA bandwidth limit responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "giga_grabber"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giga_grabber"
-version = "1.3.3"
+version = "1.3.4"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/app.rs
+++ b/src/app.rs
@@ -414,6 +414,11 @@ impl App {
                     SessionEvent::Error(error) => {
                         self.home.add_error(error);
                     }
+                    SessionEvent::OutOfBandwidth(error) => {
+                        self.home.add_error(error.clone());
+                        self.home.update(HomeMessage::PauseDownloads);
+                        self.error_modal = Some(error);
+                    }
                     SessionEvent::Drained => {
                         drained = true;
                     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -208,6 +208,7 @@ pub(crate) async fn run_cli(args: CliArgs) -> Result<()> {
         }
     });
 
+    let mut out_of_bandwidth = false;
     while let Some(msg) = message_receiver.recv().await {
         let events = session.handle_runner_message(msg);
         let mut drained = false;
@@ -225,6 +226,11 @@ pub(crate) async fn run_cli(args: CliArgs) -> Result<()> {
                 SessionEvent::Error(err) => {
                     pb.println(format!("Error: {err}"));
                 }
+                SessionEvent::OutOfBandwidth(err) => {
+                    pb.println(format!("Error: {err}"));
+                    out_of_bandwidth = true;
+                    drained = true;
+                }
                 SessionEvent::Drained => {
                     drained = true;
                 }
@@ -237,9 +243,14 @@ pub(crate) async fn run_cli(args: CliArgs) -> Result<()> {
     }
 
     session.finish().await;
+    if !progress_task.is_finished() {
+        progress_task.abort();
+    }
     let _ = progress_task.await;
 
-    if total_bytes > 0 {
+    if out_of_bandwidth {
+        pb.finish_with_message("Downloads paused: MEGA is out of bandwidth");
+    } else if total_bytes > 0 {
         pb.finish_with_message("Download complete");
     } else {
         pb.finish_with_message("Download(s) complete");

--- a/src/session.rs
+++ b/src/session.rs
@@ -14,6 +14,7 @@ pub(crate) enum SessionEvent {
     TransferActive(Download),
     TransferTerminal(String),
     Error(String),
+    OutOfBandwidth(String),
     Drained,
 }
 
@@ -143,6 +144,10 @@ impl<D: DownloadDriver> TransferSession<D> {
             RunnerMessage::Error { session_id, error } if session_id == self.id => {
                 events.push(SessionEvent::Error(error))
             }
+            RunnerMessage::OutOfBandwidth { session_id, error } if session_id == self.id => {
+                self.pause_all_transfers();
+                events.push(SessionEvent::OutOfBandwidth(error));
+            }
             RunnerMessage::Finished if self.transfers.is_empty() => {
                 events.push(SessionEvent::Drained);
             }
@@ -203,6 +208,12 @@ impl<D: DownloadDriver> TransferSession<D> {
     fn drain_download_queue(&mut self) {
         while let Ok(Some(download)) = self.download_receiver.try_recv() {
             download.cancel();
+        }
+    }
+
+    fn pause_all_transfers(&self) {
+        for download in self.transfers.values() {
+            download.pause();
         }
     }
 }
@@ -422,6 +433,36 @@ mod tests {
 
         assert!(!session.has_live_transfers());
         session.finish().await;
+    }
+
+    #[tokio::test]
+    async fn test_session_out_of_bandwidth_pauses_tracked_downloads() {
+        let temp = TempDir::new().expect("temp dir");
+        let first = make_download("bandwidth-first.bin", 1024, temp.path().to_path_buf());
+        let second = make_download("bandwidth-second.bin", 1024, temp.path().to_path_buf());
+        let mut session = TransferSession::new(
+            make_driver(vec![DriverAction::Hang, DriverAction::Hang]),
+            Config::default(),
+        );
+        let (runner_sender, _runner_receiver) = channel(64);
+        session.set_runner_sender(runner_sender);
+        session
+            .add_downloads(vec![first.clone(), second.clone()])
+            .expect("queue downloads");
+
+        let events = session.handle_runner_message(RunnerMessage::OutOfBandwidth {
+            session_id: session.id,
+            error: "MEGA is out of bandwidth".to_string(),
+        });
+
+        assert!(matches!(
+            events.as_slice(),
+            [SessionEvent::OutOfBandwidth(error)] if error.contains("out of bandwidth")
+        ));
+        assert!(first.is_paused());
+        assert!(second.is_paused());
+
+        session.abort_background();
     }
 
     #[tokio::test]

--- a/src/worker/mega_client.rs
+++ b/src/worker/mega_client.rs
@@ -1,6 +1,6 @@
 use crate::ProxyMode;
 use crate::config::Config;
-use crate::worker::{Download, PauseState};
+use crate::worker::{Download, OutOfBandwidthError, PauseState};
 use aes::Aes128;
 use anyhow::{Context, Result, bail};
 use base64::Engine;
@@ -12,7 +12,7 @@ use cipher::{BlockDecrypt, BlockDecryptMut, KeyIvInit, StreamCipher};
 use ctr::Ctr128BE;
 use futures::StreamExt;
 use log::error;
-use reqwest::{Client, Proxy, header};
+use reqwest::{Client, Proxy, StatusCode, header};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::io::SeekFrom;
@@ -211,10 +211,11 @@ impl MegaClient {
                 return Ok(false);
             }
             result = req.send() => {
-                result
-                    .context("MEGA file download request failed")?
-                    .error_for_status()
-                    .context("MEGA file download HTTP error")?
+                let response = result.context("MEGA file download request failed")?;
+                if is_out_of_bandwidth_status(response.status()) {
+                    return Err(OutOfBandwidthError.into());
+                }
+                response.error_for_status().context("MEGA file download HTTP error")?
             }
         };
 
@@ -595,6 +596,10 @@ impl MegaClient {
 
         Ok(nodes_map)
     }
+}
+
+fn is_out_of_bandwidth_status(status: StatusCode) -> bool {
+    status.as_u16() == 509
 }
 
 /// Internal request enum for MEGA `cs` calls

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -2,6 +2,8 @@ use crate::config::Config;
 use crate::worker::mega_client::MegaClient;
 use crate::{MegaFile, WorkerHandle};
 use log::error;
+use std::error::Error;
+use std::fmt;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -138,11 +140,24 @@ impl Download {
 #[derive(Debug, Clone)]
 pub(crate) enum RunnerMessage {
     /// notifies UI that this download has become active
-    Active { session_id: u64, download: Download },
+    Active {
+        session_id: u64,
+        download: Download,
+    },
     /// notifies the UI that this download is finished
-    Inactive { session_id: u64, handle: String },
+    Inactive {
+        session_id: u64,
+        handle: String,
+    },
     /// notifies the UI when non-critical errors bubble up
-    Error { session_id: u64, error: String },
+    Error {
+        session_id: u64,
+        error: String,
+    },
+    OutOfBandwidth {
+        session_id: u64,
+        error: String,
+    },
     /// may be emitted during shutdown
     Finished,
 }
@@ -154,6 +169,17 @@ pub(crate) enum RetryDecision {
     TryNow,
     GiveUp,
 }
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct OutOfBandwidthError;
+
+impl fmt::Display for OutOfBandwidthError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("MEGA is out of bandwidth. Downloads have been paused until the daily transfer limit resets.")
+    }
+}
+
+impl Error for OutOfBandwidthError {}
 
 pub(crate) trait DownloadDriver: Send + Sync + Clone + 'static {
     fn download_file(
@@ -383,6 +409,44 @@ pub(crate) async fn worker<D: DownloadDriver>(
                             }
                             Err(error) => {
                                 error!("Error downloading file: {error:?}");
+                                if error.downcast_ref::<OutOfBandwidthError>().is_some() {
+                                    download.pause();
+                                    download.mark_paused_if_requested();
+                                    message_sender
+                                        .send(RunnerMessage::OutOfBandwidth {
+                                            session_id,
+                                            error: error.to_string(),
+                                        })
+                                        .await?;
+
+                                    let mut pause_receiver = download.pause_receiver();
+                                    loop {
+                                        if *pause_receiver.borrow() == PauseState::Running {
+                                            break;
+                                        }
+
+                                        select! {
+                                            _ = cancellation_token.cancelled() => break 'worker,
+                                            _ = download.stop.cancelled() => {
+                                                message_sender
+                                                    .send(RunnerMessage::Inactive {
+                                                        session_id,
+                                                        handle: download.node.handle.clone(),
+                                                    })
+                                                    .await?;
+                                                continue 'worker;
+                                            }
+                                            result = pause_receiver.changed() => {
+                                                if result.is_err() {
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    download_sender.send(download).await?;
+                                    continue;
+                                }
                                 // keep track of per-download retries
                                 download.set_retried().await;
                                 // report error to UI

--- a/src/worker/tests.rs
+++ b/src/worker/tests.rs
@@ -286,6 +286,113 @@ async fn spawn_local_mega_fixture(
     (base_url, state, shutdown, server)
 }
 
+async fn spawn_local_mega_bandwidth_limit_fixture() -> (
+    Url,
+    Arc<AtomicUsize>,
+    CancellationToken,
+    tokio::task::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind local fixture");
+    let addr = listener.local_addr().expect("fixture local addr");
+    let base_url = Url::parse(&format!("http://{addr}/")).expect("fixture base URL");
+    let download_requests = Arc::new(AtomicUsize::new(0));
+    let requests_for_task = download_requests.clone();
+    let shutdown = CancellationToken::new();
+    let shutdown_for_task = shutdown.clone();
+
+    let server = tokio::spawn(async move {
+        loop {
+            let accept_result = tokio::select! {
+                _ = shutdown_for_task.cancelled() => break,
+                result = listener.accept() => result,
+            };
+            let Ok((mut socket, _)) = accept_result else {
+                break;
+            };
+
+            let mut request = Vec::new();
+            let mut buf = [0_u8; 2048];
+            let header_end = loop {
+                let read = match socket.read(&mut buf).await {
+                    Ok(0) => break None,
+                    Ok(n) => n,
+                    Err(_) => break None,
+                };
+                request.extend_from_slice(&buf[..read]);
+                if let Some(idx) = request.windows(4).position(|w| w == b"\r\n\r\n") {
+                    break Some(idx + 4);
+                }
+            };
+            let Some(header_end) = header_end else {
+                continue;
+            };
+
+            let request_head = String::from_utf8_lossy(&request[..header_end]);
+            let mut lines = request_head.split("\r\n");
+            let request_line = lines.next().unwrap_or_default();
+            let mut parts = request_line.split_whitespace();
+            let method = parts.next().unwrap_or_default();
+            let path = parts.next().unwrap_or_default();
+
+            let mut content_length = 0usize;
+            for line in lines {
+                if line.is_empty() {
+                    break;
+                }
+                if let Some((name, value)) = line.split_once(':')
+                    && name.eq_ignore_ascii_case("content-length")
+                {
+                    content_length = value.trim().parse::<usize>().unwrap_or(0);
+                }
+            }
+
+            let body_read = request.len().saturating_sub(header_end);
+            if content_length > body_read {
+                let mut remaining = content_length - body_read;
+                while remaining > 0 {
+                    let read = match socket.read(&mut buf).await {
+                        Ok(0) => break,
+                        Ok(n) => n,
+                        Err(_) => break,
+                    };
+                    remaining = remaining.saturating_sub(read);
+                }
+            }
+
+            if method == "POST" && path.starts_with("/cs") {
+                let cs_body = format!(r#"[{{"g":"http://{addr}/file","s":1024,"at":"QQ"}}]"#);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    cs_body.len(),
+                    cs_body
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+                continue;
+            }
+
+            if method == "GET" && path == "/file" {
+                requests_for_task.fetch_add(1, Ordering::SeqCst);
+                let _ = socket
+                    .write_all(
+                        b"HTTP/1.1 509 Bandwidth Limit Exceeded\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                    )
+                    .await;
+                continue;
+            }
+
+            let _ = socket
+                .write_all(
+                    b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .await;
+        }
+    });
+
+    (base_url, download_requests, shutdown, server)
+}
+
 #[tokio::test]
 async fn test_real_mega_client_pause_during_send_and_stream_then_resume_and_complete() {
     let temp = TempDir::new().expect("temp dir");
@@ -372,6 +479,69 @@ async fn test_real_mega_client_pause_during_send_and_stream_then_resume_and_comp
         .await
         .expect("fixture task join timeout")
         .expect("fixture task join failure");
+}
+
+#[tokio::test]
+async fn test_real_mega_client_509_pauses_without_retrying() {
+    let temp = TempDir::new().expect("temp dir");
+    let (base_url, download_requests, fixture_shutdown, fixture_task) =
+        spawn_local_mega_bandwidth_limit_fixture().await;
+
+    let download = make_download("bandwidth-limit.bin", 1024, temp.path().to_path_buf());
+    let (download_sender, download_receiver) = kanal::unbounded_async();
+    let (message_sender, mut message_receiver) = channel(64);
+    let cancel = CancellationToken::new();
+    let config = Arc::new(Config {
+        max_retries: 3,
+        min_retry_delay: Duration::ZERO,
+        max_retry_delay: Duration::ZERO,
+        ..Default::default()
+    });
+    let mega = MegaClient::with_origin(reqwest::Client::new(), base_url);
+
+    let workers = spawn_workers(
+        mega,
+        config,
+        download_receiver,
+        download_sender.clone(),
+        (message_sender, 0),
+        cancel.clone(),
+        1,
+    );
+
+    download_sender
+        .send(download.clone())
+        .await
+        .expect("enqueue download");
+
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Active { .. }
+    ));
+
+    match next_message(&mut message_receiver).await {
+        RunnerMessage::OutOfBandwidth { error, .. } => {
+            assert!(error.contains("out of bandwidth"));
+        }
+        message => panic!("expected out-of-bandwidth message, got {message:?}"),
+    }
+
+    wait_for_paused(&download).await;
+    sleep(Duration::from_millis(100)).await;
+    assert_eq!(download_requests.load(Ordering::SeqCst), 1);
+
+    download.stop.cancel();
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Inactive { .. }
+    ));
+
+    cancel.cancel();
+    for worker in workers {
+        worker.await.expect("worker join").expect("worker result");
+    }
+    fixture_shutdown.cancel();
+    fixture_task.await.expect("fixture join");
 }
 
 #[tokio::test]
@@ -725,7 +895,7 @@ async fn test_cancel_during_pause_requeue_emits_single_inactive_and_clears_activ
                 }
                 active_handles.remove(&handle);
             }
-            RunnerMessage::Error { .. } => (),
+            RunnerMessage::Error { .. } | RunnerMessage::OutOfBandwidth { .. } => (),
             RunnerMessage::Finished => (),
         }
     }
@@ -748,7 +918,7 @@ async fn test_cancel_during_pause_requeue_emits_single_inactive_and_clears_activ
                     }
                     active_handles.remove(&handle);
                 }
-                RunnerMessage::Error { .. } => (),
+                RunnerMessage::Error { .. } | RunnerMessage::OutOfBandwidth { .. } => (),
                 RunnerMessage::Finished => (),
             }
         }
@@ -882,7 +1052,7 @@ async fn test_cancel_during_retry_requeue_emits_single_inactive_and_clears_activ
                 }
                 active_handles.remove(&handle);
             }
-            RunnerMessage::Error { .. } => (),
+            RunnerMessage::Error { .. } | RunnerMessage::OutOfBandwidth { .. } => (),
             RunnerMessage::Finished => (),
         }
     }
@@ -905,7 +1075,7 @@ async fn test_cancel_during_retry_requeue_emits_single_inactive_and_clears_activ
                     }
                     active_handles.remove(&handle);
                 }
-                RunnerMessage::Error { .. } => (),
+                RunnerMessage::Error { .. } | RunnerMessage::OutOfBandwidth { .. } => (),
                 RunnerMessage::Finished => (),
             }
         }
@@ -982,6 +1152,7 @@ async fn test_rename_failure_is_reported_and_not_marked_inactive_immediately() {
                     saw_max_retries_error = true;
                 }
             }
+            RunnerMessage::OutOfBandwidth { .. } => (),
             RunnerMessage::Inactive { .. } => saw_inactive = true,
             RunnerMessage::Active { .. } => (),
             RunnerMessage::Finished => (),
@@ -1038,6 +1209,7 @@ async fn test_max_retries_exceeded() {
                     saw_max_retries_error = true;
                 }
             }
+            RunnerMessage::OutOfBandwidth { .. } => (),
             RunnerMessage::Inactive { .. } => saw_inactive = true,
             RunnerMessage::Active { .. } => (),
             RunnerMessage::Finished => (),
@@ -1145,7 +1317,7 @@ async fn test_concurrency_semaphore_limits() {
                 active_count = active_count.saturating_sub(1);
                 inactive_count += 1;
             }
-            RunnerMessage::Error { .. } => (),
+            RunnerMessage::Error { .. } | RunnerMessage::OutOfBandwidth { .. } => (),
             RunnerMessage::Finished => (),
         }
     }


### PR DESCRIPTION
## Summary
- Detect MEGA HTTP 509 bandwidth limit responses and avoid retrying them
- Pause tracked downloads and surface a clear out-of-bandwidth message in GUI and CLI
- Add regression coverage for the 509 path and bump the package version to v1.3.4

## Verification
- cargo test
- cargo clippy

Closes #20