### PR TITLE
Bump RustCrypto dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,12 +26,12 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cfg-if",
  "cipher",
+ "cpubits",
  "cpufeatures",
 ]
 
@@ -394,12 +394,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
-name = "block-padding"
-version = "0.3.3"
+name = "block-buffer"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -524,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
 dependencies = [
  "cipher",
 ]
@@ -563,10 +572,11 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
+ "block-buffer",
  "crypto-common",
  "inout",
 ]
@@ -808,10 +818,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "cpubits"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -852,12 +868,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -868,9 +883,9 @@ checksum = "e162d0c2e2068eb736b71e5597eff0b9944e6b973cd9f37b6a288ab9bf20e300"
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
  "cipher",
 ]
@@ -1326,16 +1341,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,6 +1641,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2036,12 +2050,12 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "block-padding",
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -4476,9 +4490,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uds_windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aes = "0.8"
+aes = "0.9.1"
 anyhow = "1"
 base64 = "0.22"
-cbc = { version = "0.1", features = ["alloc"] }
-cipher = "0.4"
+cbc = { version = "0.2.1", features = ["alloc"] }
+cipher = "0.5.2"
 clap = { version = "4.5", features = ["derive"] }
-ctr = "0.9"
+ctr = "0.10.1"
 fastrand = "2"
 futures = "0.3"
 iced = { version = "0.14.0", optional = true, features = ["tokio", "canvas", "svg", "advanced"] }

--- a/src/worker/mega_client.rs
+++ b/src/worker/mega_client.rs
@@ -6,9 +6,10 @@ use anyhow::{Context, Result, bail};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use cbc::Decryptor;
+use cipher::BlockCipherDecrypt;
 use cipher::KeyInit;
 use cipher::StreamCipherSeek;
-use cipher::{BlockDecrypt, BlockDecryptMut, KeyIvInit, StreamCipher};
+use cipher::{BlockModeDecrypt, KeyIvInit, StreamCipher};
 use ctr::Ctr128BE;
 use futures::StreamExt;
 use log::error;
@@ -745,9 +746,12 @@ fn parse_public_link(url: &str) -> Result<ParsedPublicLink> {
 }
 
 /// AES-ECB decrypt `data` in-place using `key`
-fn decrypt_ebc_in_place(key: &[u8], data: &mut [u8]) {
+fn decrypt_ebc_in_place(key: &[u8; 16], data: &mut [u8]) {
     let aes = Aes128::new(key.into());
-    for block in data.chunks_mut(16) {
+    for block in data.chunks_exact_mut(16) {
+        let block: &mut [u8; 16] = block
+            .try_into()
+            .expect("chunks_exact_mut yields 16-byte blocks");
         aes.decrypt_block(block.into());
     }
 }
@@ -834,7 +838,10 @@ fn decrypt_attrs(aes_key: &[u8; 16], attr_b64: &str) -> Result<String> {
 
     let mut cbc = Decryptor::<Aes128>::new(aes_key.into(), &Default::default());
     for chunk in buf.chunks_exact_mut(16) {
-        cbc.decrypt_block_mut(chunk.into());
+        let block: &mut [u8; 16] = chunk
+            .try_into()
+            .expect("chunks_exact_mut yields 16-byte blocks");
+        cbc.decrypt_block(block.into());
     }
 
     if &buf[..4] != b"MEGA" {
@@ -865,9 +872,8 @@ async fn pause_loop(pause_receiver: &mut watch::Receiver<PauseState>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aes::cipher::BlockEncrypt;
     use cbc::Encryptor;
-    use cipher::{BlockEncryptMut, KeyIvInit};
+    use cipher::{BlockCipherEncrypt, BlockModeEncrypt, KeyIvInit};
     use serde_json::json;
     use std::collections::BTreeMap;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -876,7 +882,10 @@ mod tests {
 
     fn ecb_encrypt_in_place(key: &[u8; 16], data: &mut [u8]) {
         let aes = Aes128::new(key.into());
-        for block in data.chunks_mut(16) {
+        for block in data.chunks_exact_mut(16) {
+            let block: &mut [u8; 16] = block
+                .try_into()
+                .expect("chunks_exact_mut yields 16-byte blocks");
             aes.encrypt_block(block.into());
         }
     }
@@ -903,7 +912,10 @@ mod tests {
 
         let mut cbc = Encryptor::<Aes128>::new(aes_key.into(), &Default::default());
         for chunk in plain.chunks_exact_mut(16) {
-            cbc.encrypt_block_mut(chunk.into());
+            let block: &mut [u8; 16] = chunk
+                .try_into()
+                .expect("chunks_exact_mut yields 16-byte blocks");
+            cbc.encrypt_block(block.into());
         }
         URL_SAFE_NO_PAD.encode(plain)
     }


### PR DESCRIPTION
## Summary
- Updates aes to 0.9.1, ctr to 0.10.1, cbc to 0.2.1, and cipher to 0.5.2 using latest versions from crates.io
- Migrates MEGA crypto code to cipher 0.5 trait names and fixed block conversions

Closes #29

## Validation
- cargo check
- cargo fmt --check
- cargo clippy --all-targets --all-features
- cargo test --all-features