### PR TITLE
Add persistent download session restore

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - `src/app/` contains the Iced GUI code.
 - `src/cli.rs` contains the CLI code.
 - `docs/solutions/` stores documented solutions to past problems and practices, organized by category with YAML frontmatter (`module`, `tags`, `problem_type`); relevant when implementing or debugging in documented areas.
+- `docs/CONCEPTS.md` stores shared project vocabulary and is the only canonical location for concepts documentation.
 
 ## Development Rules
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,9 +26,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher",
  "cpubits",
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -73,7 +73,7 @@ dependencies = [
  "ndk-context",
  "ndk-sys",
  "num_enum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -93,9 +93,9 @@ checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -311,13 +311,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -334,9 +334,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.3"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
@@ -360,6 +360,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bit-set"
@@ -460,13 +466,13 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -543,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -589,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -599,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -611,14 +617,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -662,7 +668,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd63e33452ffdafd39924c4f05a5dd1e94db646c779c6bd59148a3d95fff5ad4"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "x11rb",
 ]
 
@@ -931,13 +937,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -984,9 +990,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -1070,11 +1076,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1106,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "flate2"
@@ -1155,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "font-types"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad67eced03f5504d9cbd3a879b5958b5c54d4e5fd794361c6eb21b05fb703411"
+checksum = "0a7299a780854a6d391be2ae1c8521c9368471b559dbfd6a8dbd9f407eaff100"
 dependencies = [
  "bytemuck",
 ]
@@ -1197,13 +1202,13 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-macros"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1399,7 +1404,7 @@ version = "1.3.6"
 dependencies = [
  "aes",
  "anyhow",
- "base64",
+ "base64 0.23.1",
  "cbc",
  "cipher",
  "clap",
@@ -1598,9 +1603,9 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1637,18 +1642,18 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1685,7 +1690,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1715,7 +1720,7 @@ dependencies = [
  "iced_runtime",
  "iced_widget",
  "iced_winit",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1732,7 +1737,7 @@ dependencies = [
  "num-traits",
  "rustc-hash 2.1.3",
  "smol_str",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "web-time",
 ]
 
@@ -1778,7 +1783,7 @@ dependencies = [
  "lyon_path",
  "raw-window-handle",
  "rustc-hash 2.1.3",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "unicode-segmentation",
 ]
 
@@ -1802,7 +1807,7 @@ dependencies = [
  "iced_tiny_skia",
  "iced_wgpu",
  "log",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1815,7 +1820,7 @@ dependencies = [
  "iced_core",
  "iced_futures",
  "raw-window-handle",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1854,7 +1859,7 @@ dependencies = [
  "lyon",
  "resvg",
  "rustc-hash 2.1.3",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wgpu",
 ]
 
@@ -1868,7 +1873,7 @@ dependencies = [
  "log",
  "num-traits",
  "rustc-hash 2.1.3",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "unicode-segmentation",
 ]
 
@@ -1883,7 +1888,7 @@ dependencies = [
  "log",
  "mundy",
  "rustc-hash 2.1.3",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2045,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2082,7 +2087,7 @@ dependencies = [
  "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -2140,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2205,9 +2210,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -2227,21 +2232,21 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "bitflags 2.13.1",
  "libc",
  "plain",
- "redox_syscall 0.9.0",
+ "redox_syscall 0.9.1",
 ]
 
 [[package]]
 name = "lilt"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67562e5eff6b20553fa9be1c503356768420994e28f67e3eafe6f41910e57ad"
+checksum = "337d4c256f7d9f2dbd633891d48ace853efa5b1554122d9220b172ad9c03c3a9"
 dependencies = [
  "web-time",
 ]
@@ -2480,7 +2485,7 @@ dependencies = [
  "once_cell",
  "rustc-hash 1.1.0",
  "spirv",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "unicode-ident",
 ]
 
@@ -2500,7 +2505,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation 0.3.2",
  "raw-window-handle",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "versions",
  "wfd",
  "which",
@@ -3184,9 +3189,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -3205,7 +3210,7 @@ dependencies = [
  "rustc-hash 2.1.3",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -3228,7 +3233,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3331,7 +3336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
 dependencies = [
  "bytemuck",
- "font-types 0.12.1",
+ "font-types 0.12.2",
  "once_cell",
 ]
 
@@ -3361,9 +3366,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
+checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -3382,9 +3387,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3409,7 +3414,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3538,9 +3543,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3564,9 +3569,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3740,14 +3745,14 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -3764,7 +3769,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3911,7 +3916,7 @@ dependencies = [
  "log",
  "memmap2",
  "rustix 1.1.4",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
@@ -4067,9 +4072,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.0"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4138,11 +4143,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -4158,13 +4163,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4244,9 +4249,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -4259,13 +4264,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4280,9 +4285,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4314,9 +4319,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -4521,7 +4526,7 @@ version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "data-url",
  "flate2",
  "fontdb",
@@ -4617,9 +4622,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4630,9 +4635,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4640,9 +4645,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4650,9 +4655,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4663,9 +4668,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -4699,9 +4704,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -4713,9 +4718,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.14"
+version = "0.31.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
 dependencies = [
  "bitflags 2.13.1",
  "rustix 1.1.4",
@@ -4811,9 +4816,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -4834,9 +4839,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4930,7 +4935,7 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
  "wgpu-core-deps-windows-linux-android",
@@ -5006,7 +5011,7 @@ dependencies = [
  "raw-window-handle",
  "renderdoc-sys",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -5024,7 +5029,7 @@ dependencies = [
  "bytemuck",
  "js-sys",
  "log",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "web-sys",
 ]
 
@@ -5082,7 +5087,7 @@ dependencies = [
  "clipboard_wayland",
  "clipboard_x11",
  "raw-window-handle",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5463,9 +5468,9 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xcursor"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+checksum = "163b33ed8786455e2fa5d72f554057ce3f3182425434f756cd39c99839d88e23"
 
 [[package]]
 name = "xkbcommon-dl"
@@ -5488,9 +5493,9 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.28"
+version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
 
 [[package]]
 name = "xmlwriter"
@@ -5596,18 +5601,18 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "giga_grabber"
-version = "1.3.5"
+version = "1.3.6"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,16 +6,16 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aes = "0.9.1"
+aes = "0.9"
 anyhow = "1"
-base64 = "0.22"
-cbc = { version = "0.2.1", features = ["alloc"] }
-cipher = "0.5.2"
+base64 = "0.23"
+cbc = { version = "0.2", features = ["alloc"] }
+cipher = "0.5"
 clap = { version = "4.5", features = ["derive"] }
-ctr = "0.10.1"
+ctr = "0.10"
 fastrand = "2"
 futures = "0.3"
-iced = { version = "0.14.0", optional = true, features = ["tokio", "canvas", "svg", "advanced"] }
+iced = { version = "0.14", optional = true, features = ["tokio", "canvas", "svg", "advanced"] }
 indicatif = "0.18"
 kanal = "0.1"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giga_grabber"
-version = "1.3.5"
+version = "1.3.6"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -1,0 +1,17 @@
+# Concepts
+
+Shared domain vocabulary for this project — entities, named processes, and status concepts with project-specific meaning. Seeded with core domain vocabulary, then accretes as ce-compound and ce-compound-refresh process learnings; direct edits are fine. Glossary only, not a spec or catch-all.
+
+## Transfer Restoration
+
+### Download Session
+A durable snapshot of unfinished GUI transfers containing the source identity and destination needed to reconstruct them after a graceful application close.
+
+### Download Session Record
+One persisted transfer identity within a Download Session; newly created records require queue acceptance and terminal transfers remove their records, while a failed source refetch initially retains a record unless bulk cancellation or a later session drain clears it.
+
+### Restored Download
+A reconstructed unfinished transfer that begins paused and obtains resumable progress from its partial output, requiring an explicit resume before transfer work continues.
+
+### Bulk Transfer Control
+The Home-screen action that pauses or resumes every visible transfer, derived from their current pause states rather than separately cached UI state.

--- a/docs/solutions/best-practices/session-centered-transfer-core-2026-04-18.md
+++ b/docs/solutions/best-practices/session-centered-transfer-core-2026-04-18.md
@@ -42,11 +42,12 @@ pub(crate) enum SessionEvent {
     TransferActive(Download),
     TransferTerminal(String),
     Error(String),
+    OutOfBandwidth(String),
     Drained,
 }
 ```
 
-`add_downloads()` makes append behavior idempotent per handle and starts workers only when needed. `handle_runner_message()` is the single place where worker activity becomes `TransferActive`, `TransferTerminal`, `Error`, or `Drained`.
+`add_downloads()` makes append behavior idempotent per handle and starts workers only when needed. `handle_runner_message()` is the single place where worker activity becomes `TransferActive`, `TransferTerminal`, `Error`, `OutOfBandwidth`, or `Drained`.
 
 The worker layer now includes `session_id` on per-download runner messages so a fresh session can safely ignore stale events from an older one:
 
@@ -55,6 +56,7 @@ pub(crate) enum RunnerMessage {
     Active { session_id: u64, download: Download },
     Inactive { session_id: u64, handle: String },
     Error { session_id: u64, error: String },
+    OutOfBandwidth { session_id: u64, error: String },
     Finished,
 }
 ```
@@ -94,6 +96,7 @@ while let Some(msg) = message_receiver.recv().await {
                 format_size(download.node.size)
             )),
             SessionEvent::Error(err) => pb.println(format!("Error: {err}")),
+            SessionEvent::OutOfBandwidth(err) => pb.println(format!("Bandwidth limit: {err}")),
             SessionEvent::Drained => break,
             SessionEvent::TransferTerminal(_) => {}
         }

--- a/docs/solutions/logic-errors/download-session-persistence-prerequisites-2026-08-09.md
+++ b/docs/solutions/logic-errors/download-session-persistence-prerequisites-2026-08-09.md
@@ -1,0 +1,76 @@
+---
+title: Persist Accepted Transfers and Retain Retryable Restore Records
+date: 2026-08-09
+category: logic-errors
+module: session-persistence
+problem_type: logic_error
+component: tooling
+symptoms:
+  - No session file is retained when no current transfer or retryable restore record remains
+  - Session restoration skips stale completed files and invalid source nodes
+root_cause: missing_workflow_step
+resolution_type: code_fix
+severity: medium
+related_components:
+  - app
+  - session
+  - worker
+  - config
+tags:
+  - session-persistence
+  - download-restore
+  - graceful-shutdown
+  - working-directory
+---
+
+# Persist Accepted Transfers and Retain Retryable Restore Records
+
+## Problem
+
+Download-session persistence must save enough provenance to reconstruct unfinished GUI work, while avoiding records for rejected, completed, or cancelled transfers. A failed source refetch initially retains its record for a later restore attempt, unless bulk cancellation or a later session drain clears it.
+
+## Symptoms
+
+- A session file is intentionally absent when the active-record set is empty.
+- A saved record may not restore when its final output file already exists, its source cannot be fetched, or its node metadata no longer matches.
+
+## What Didn't Work
+
+- Treating the settings checkbox as immediate state is incorrect. The runtime shutdown gate changes after the settings save action succeeds.
+- Treating a selected download as persistable is incorrect. A record is valid only after `TransferSession::add_downloads` accepts its handle.
+- Persisting progress in JSON is unnecessary. Resume progress comes from the partial output file when `Download::restore` reconstructs the download.
+
+## Solution
+
+Maintain `DownloadSessionRecord` entries for accepted GUI downloads, snapshot those records on graceful close, and remove records as transfers become terminal or the session drains. When a source refetch fails during restore, retain its record for a later launch unless bulk cancellation or a later session drain clears it. Store only source URL, node handle, destination directory, and expected size.
+
+```rust
+let records: Vec<_> = self.download_records.values().cloned().collect();
+if records.is_empty() {
+    session_persistence::remove()
+} else {
+    session_persistence::save(&records)
+}
+```
+
+On startup, load the records, refetch their public source nodes, validate the node handle, kind, and expected size, then call `Download::restore`. That constructor pauses valid restored downloads and derives displayed progress from the partial file length.
+
+## Why This Works
+
+The session file represents durable transfer identity, not volatile worker state. Accepted handles prevent records for rejected queue entries. Terminal and drained cleanup prevent replaying completed work, while a failed source refetch initially retains a retryable record. Restore verifies the stored handle, file kind, and expected size before reconstructing a download. The partial file remains the source of truth for resumable progress.
+
+Both `config.json` and `download-session.json` are relative paths, so they are resolved from the GUI process working directory. Inspect the actual launch directory when a local file appears missing.
+
+## Prevention
+
+- Save the settings form before expecting the runtime persistence gate to change.
+- Add records only after queue acceptance; remove them on terminal transfer events and drain, and document that retryable restore records are also cleared by bulk cancellation or a later drain.
+- Restore downloads paused, then require an explicit resume before transfer work begins.
+- Cover serialization round trips, missing and corrupt session files, queue acceptance provenance, and paused restored downloads.
+
+## Related Issues
+
+- `src/session_persistence.rs` - JSON session format and atomic replacement.
+- `src/app.rs` - record ownership, shutdown snapshot, and restore orchestration.
+- `src/worker/mod.rs` - paused restoration and partial-file progress recovery.
+- `docs/solutions/best-practices/session-centered-transfer-core-2026-04-18.md` - shared transfer lifecycle ownership.

--- a/docs/solutions/ui-bugs/iced-native-close-session-snapshot-2026-08-09.md
+++ b/docs/solutions/ui-bugs/iced-native-close-session-snapshot-2026-08-09.md
@@ -1,0 +1,67 @@
+---
+title: Preserve Iced Session Snapshots on Native Window Close
+date: 2026-08-09
+category: ui-bugs
+module: app-shutdown
+problem_type: ui_bug
+component: tooling
+symptoms:
+  - Native window close exits without creating download-session.json
+  - Active downloads are absent after reopening the GUI
+root_cause: wrong_api
+resolution_type: code_fix
+severity: high
+related_components:
+  - app
+  - session-persistence
+  - iced
+tags:
+  - iced
+  - window-close
+  - session-persistence
+  - async-shutdown
+---
+
+# Preserve Iced Session Snapshots on Native Window Close
+
+## Problem
+
+The GUI queued a download-session snapshot from `window::close_requests()`, but closing through the native title-bar control exited before that subscription could run.
+
+## Symptoms
+
+- A saved persistence setting and active download still produced no `download-session.json` file on normal window close.
+- Reopening the application had no download record to restore.
+
+## What Didn't Work
+
+- Verifying only the saved `persist_download_sessions` configuration did not explain the missing file. The setting was enabled, but the close message was never delivered.
+- Scheduling `Task::perform` from the existing close-message branch could not help while the native event bypassed the branch entirely.
+
+## Solution
+
+Disable Iced's automatic exit on close requests, then let the existing message chain save the snapshot before explicitly closing the window.
+
+```rust
+iced::application(App::new, App::update, App::view)
+    .subscription(App::subscription)
+    .exit_on_close_request(false)
+```
+
+`App::update` receives `CloseRequested`, starts the session save task, and calls `close_window()` only after `CloseSnapshotFinished(Ok(()))`. `close_window()` then requests the final Iced window close.
+
+## Why This Works
+
+Iced 0.14 enables `exit_on_close_request` by default. With that setting enabled, its native runner closes the window directly instead of publishing the close event that `window::close_requests()` listens for. Setting it to `false` preserves the event for the application subscription, allowing the asynchronous write to finish before the app issues its own close command.
+
+## Prevention
+
+- For any Iced close handler that must flush state, set `exit_on_close_request(false)` on the application builder.
+- Keep shutdown ordering explicit: close request, durable write, completion message, then `window::close`.
+- Test the persisted artifact through a native-close smoke test when desktop GUI automation is available: save `persist_download_sessions = true`, queue an accepted unfinished transfer, close the native window, wait for process exit, verify `download-session.json`, relaunch, then verify a paused restored row.
+
+## Related Issues
+
+- `src/app.rs` - application builder and close-message state machine.
+- `src/session_persistence.rs` - atomic session-file writer.
+- `docs/solutions/design-patterns/iced-update-check-settings-layout-2026-06-10.md` - related Iced `Task::perform` guidance.

--- a/docs/solutions/ui-bugs/restored-download-bulk-control-state-2026-08-09.md
+++ b/docs/solutions/ui-bugs/restored-download-bulk-control-state-2026-08-09.md
@@ -1,0 +1,71 @@
+---
+title: Derive Bulk Download Controls From Live Pause State
+date: 2026-08-09
+category: ui-bugs
+module: home-screen
+problem_type: ui_bug
+component: tooling
+symptoms:
+  - Restored paused downloads show Pause All instead of Resume All
+  - Per-transfer pause changes can leave the bulk control stale
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+related_components:
+  - app
+  - worker
+  - session
+tags:
+  - pause-resume
+  - restored-downloads
+  - home-screen
+  - ui-state
+---
+
+# Derive Bulk Download Controls From Live Pause State
+
+## Problem
+
+Restored downloads correctly entered Home paused, but the global control still displayed `Pause All` because Home stored a separate `all_paused` boolean initialized to `false`.
+
+## Symptoms
+
+- All restored downloads are paused but the global button offers `Pause All`.
+- Pausing the last running transfer through an individual control can leave the global control in the wrong state.
+
+## What Didn't Work
+
+- Updating the cached boolean only from bulk pause and resume actions leaves direct restore, individual controls, and lifecycle removals as desynchronization paths.
+- Adding another restore-specific boolean assignment would only fix one entry path and would retain the stale-cache design.
+
+## Solution
+
+Remove the cache and derive the bulk action from visible downloads whenever Home renders.
+
+```rust
+fn bulk_control_message(&self) -> Message {
+    if self.active_downloads.values().all(Download::is_paused) {
+        Message::ResumeDownloads
+    } else {
+        Message::PauseDownloads
+    }
+}
+```
+
+The view maps `ResumeDownloads` to `Resume All`; otherwise it maps to `Pause All`.
+
+## Why This Works
+
+`Download::restore` deliberately pauses each reconstructed download before Home receives it. Evaluating `Download::is_paused()` from Home's current visible transfers reflects that state regardless of whether it came from restore, an individual action, or a bulk action. The nonempty download-list guard means the empty-set behavior is never rendered as a bulk control.
+
+## Prevention
+
+- Derive presentation decisions from authoritative transfer state instead of duplicating lifecycle flags in UI models.
+- Test all-paused, all-running, and mixed visible-transfer cases as action enums rather than label text.
+- Include restored paused downloads in state-matrix coverage because they enter Home outside the normal runner-active event path.
+
+## Related Issues
+
+- `src/app/screens/home.rs` - Home state and bulk button rendering.
+- `src/app/screens/home/tests.rs` - pause-state action matrix.
+- `src/worker/mod.rs` - `Download::is_paused` and restore pause behavior.

--- a/src/app.rs
+++ b/src/app.rs
@@ -747,6 +747,7 @@ pub(crate) fn build_app() -> iced::Application<impl iced::Program<Message = Mess
         .title(App::title)
         .subscription(App::subscription)
         .theme(App::theme)
+        .exit_on_close_request(false)
         .window_size((700.0, 550.0))
         .font(CABIN_REGULAR)
         .font(INCONSOLATA_MEDIUM)

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,16 +1,19 @@
 use crate::app::components::{modal, nav_sidebar};
 use crate::app::helpers::*;
+use crate::app::screens::choose_files::QueuedDownload;
+use crate::app::screens::import::ImportedFiles;
 use crate::app::screens::*;
 use crate::config::Config;
 use crate::mega_client::MegaClient;
+use crate::session_persistence::{self, DownloadSessionRecord};
 use crate::update_check::{self, ReleaseInfo, UpdateCheckError, UpdateStatus};
 use crate::worker::mega_client::mega_builder;
-use crate::{MegaFile, RunnerMessage, SessionEvent, TransferSession};
+use crate::{Download, MegaFile, NodeKind, RunnerMessage, SessionEvent, TransferSession};
 use iced::font::{Family, Weight};
 use iced::time::every;
 use iced::widget::{Row, container, text};
-use iced::{Element, Font, Length, Subscription, Task, Theme};
-use std::collections::HashSet;
+use iced::{Element, Font, Length, Subscription, Task, Theme, window};
+use std::collections::{HashMap, HashSet};
 use std::process::Command;
 use std::time::Duration;
 use tokio::sync::mpsc::Sender as TokioSender;
@@ -35,15 +38,34 @@ pub(crate) struct App {
     session: Option<TransferSession<MegaClient>>,
     runner_sender: Option<TokioSender<RunnerMessage>>,
     file_handles: HashSet<String>,
+    download_records: HashMap<String, DownloadSessionRecord>,
+    persist_download_sessions: bool,
+    restore_started: bool,
+    close_pending: bool,
     route: Route,
     error_modal: Option<String>,
     update_release: Option<ReleaseInfo>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RestoredDownloads {
+    downloads: Vec<QueuedDownload>,
+    retained_records: Vec<DownloadSessionRecord>,
+    errors: Vec<String>,
 }
 
 impl App {
     fn new() -> (Self, Task<Message>) {
         // load config from disk, falling back to a default config if needed
         let (mut config, mut error_modal) = Config::new();
+        let persist_download_sessions = config.persist_download_sessions;
+        if !config.persist_download_sessions
+            && let Err(error) = session_persistence::remove()
+        {
+            error_modal.get_or_insert_with(|| {
+                format!("Failed to remove disabled download session: {error}")
+            });
+        }
         // build the mega client, falling back to default config if needed
         let mega = loop {
             if let Ok(client) = mega_builder(&config) {
@@ -65,6 +87,10 @@ impl App {
             session: None,
             runner_sender: None,
             file_handles: HashSet::new(),
+            download_records: HashMap::new(),
+            persist_download_sessions,
+            restore_started: false,
+            close_pending: false,
             route: Route::Home,
             error_modal,
             update_release: None,
@@ -116,6 +142,8 @@ impl App {
             Message::Home(msg) => match self.home.update(msg) {
                 HomeAction::None => Task::none(),
                 HomeAction::StopWorkers => {
+                    self.remove_persisted_session();
+                    self.download_records.clear();
                     if let Some(session) = &mut self.session {
                         session.abort_background();
                     }
@@ -134,7 +162,7 @@ impl App {
                             .map_or_else(HashSet::new, TransferSession::handles),
                     );
                     let mut accepted: Vec<MegaFile> = Vec::new();
-                    for file in files {
+                    for file in files.files {
                         let Some(file) = file.without_handles(&tracked_handles) else {
                             continue;
                         };
@@ -148,10 +176,14 @@ impl App {
                     }
 
                     if !accepted.is_empty() {
+                        let accepted = ImportedFiles {
+                            files: accepted,
+                            source_url: files.source_url,
+                        };
                         if let Some(choose_files) = &mut self.choose_files {
-                            choose_files.add_files(accepted);
+                            choose_files.add_files(vec![accepted]);
                         } else {
-                            self.choose_files = Some(ChooseFiles::new(accepted));
+                            self.choose_files = Some(ChooseFiles::new(vec![accepted]));
                         }
                     }
                     Task::none()
@@ -193,11 +225,22 @@ impl App {
 
                             if let Some(session) = &mut self.session {
                                 session.set_runner_sender(runner_sender);
-                                if let Err(error) = session.add_downloads(downloads) {
+                                let existing_handles = session.handles();
+                                let downloads_to_queue: Vec<Download> = downloads
+                                    .iter()
+                                    .map(|queued| queued.download.clone())
+                                    .collect();
+                                if let Err(error) = session.add_downloads(downloads_to_queue) {
                                     self.error_modal =
                                         Some(format!("Failed to queue downloads: {error}"));
                                     return Task::none();
                                 }
+                                let accepted_handles = session.handles();
+                                self.record_accepted_downloads(
+                                    &downloads,
+                                    &existing_handles,
+                                    &accepted_handles,
+                                );
                             }
 
                             // Navigate to home
@@ -220,8 +263,106 @@ impl App {
                     session.set_runner_sender(sender.clone());
                 }
                 self.runner_sender = Some(sender);
-                Task::none()
+                if self.persist_download_sessions && !self.restore_started {
+                    self.restore_started = true;
+                    let mega = self.mega.clone();
+                    Task::perform(restore_downloads(mega), Message::RestoreFinished)
+                } else {
+                    Task::none()
+                }
             }
+            Message::RestoreFinished(result) => match result {
+                Ok(restored) if restored.downloads.is_empty() => {
+                    self.retain_download_records(restored.retained_records);
+                    if restored.errors.is_empty() {
+                        self.remove_persisted_session();
+                    } else {
+                        self.home.add_error(restored.errors.join("\n"));
+                    }
+                    Task::none()
+                }
+                Ok(restored) => {
+                    let Some(runner_sender) = self.runner_sender.clone() else {
+                        self.error_modal = Some("Download runner is not ready yet".to_string());
+                        return Task::none();
+                    };
+
+                    self.retain_download_records(restored.retained_records);
+                    if self.session.is_none() {
+                        self.session = Some(TransferSession::new(
+                            self.mega.clone(),
+                            self.settings.config.clone(),
+                        ));
+                    }
+
+                    let session = self.session.as_mut().expect("session created when absent");
+                    session.set_runner_sender(runner_sender);
+                    let existing_handles = session.handles();
+                    let downloads_to_queue: Vec<Download> = restored
+                        .downloads
+                        .iter()
+                        .map(|queued| queued.download.clone())
+                        .collect();
+                    match session.add_downloads(downloads_to_queue) {
+                        Ok(_) => {
+                            let accepted_handles = session.handles();
+                            self.record_accepted_downloads(
+                                &restored.downloads,
+                                &existing_handles,
+                                &accepted_handles,
+                            );
+                            expose_accepted_downloads(
+                                &mut self.home,
+                                &restored.downloads,
+                                &existing_handles,
+                                &accepted_handles,
+                            );
+                            if !restored.errors.is_empty() {
+                                self.home.add_error(restored.errors.join("\n"));
+                            }
+                        }
+                        Err(error) => {
+                            self.error_modal =
+                                Some(format!("Failed to restore downloads: {error}"));
+                        }
+                    }
+                    Task::none()
+                }
+                Err(error) => {
+                    self.error_modal = Some(format!("Failed to restore downloads: {error}"));
+                    Task::none()
+                }
+            },
+            Message::CloseRequested => {
+                if self.close_pending {
+                    return Task::none();
+                }
+                self.close_pending = true;
+                if !self.persist_download_sessions {
+                    return self.close_window();
+                }
+
+                let records: Vec<_> = self.download_records.values().cloned().collect();
+                Task::perform(
+                    async move {
+                        if records.is_empty() {
+                            session_persistence::remove()
+                        } else {
+                            session_persistence::save(&records)
+                        }
+                        .map_err(|error| error.to_string())
+                    },
+                    Message::CloseSnapshotFinished,
+                )
+            }
+            Message::CloseSnapshotFinished(result) => match result {
+                Ok(()) => self.close_window(),
+                Err(error) => {
+                    self.close_pending = false;
+                    self.error_modal = Some(format!("Failed to save download session: {error}"));
+                    Task::none()
+                }
+            },
             Message::RunnerBatch(messages) => {
                 for message in messages {
                     self.handle_runner_message(message);
@@ -258,7 +399,14 @@ impl App {
             Message::Settings(msg) => {
                 match self.settings.update(msg) {
                     SettingsAction::None => Task::none(),
-                    SettingsAction::ConfigSaved => Task::none(),
+                    SettingsAction::ConfigSaved => {
+                        self.persist_download_sessions =
+                            self.settings.config.persist_download_sessions;
+                        if !self.persist_download_sessions {
+                            self.remove_persisted_session();
+                        }
+                        Task::none()
+                    }
                     SettingsAction::CheckForUpdates => Self::check_for_updates(true),
                     SettingsAction::RebuildRequired(config) => {
                         // if the worker is active, do not rebuild
@@ -394,9 +542,10 @@ impl App {
         // forces the UI to refresh every second
         // this is needed because changes to the active downloads don't trigger a refresh
         let refresh = every(Duration::from_secs(1)).map(|_| Message::Refresh);
+        let close_requests = window::close_requests().map(|_| Message::CloseRequested);
 
         // run all subscriptions in parallel
-        Subscription::batch(vec![runner_subscription, refresh])
+        Subscription::batch(vec![runner_subscription, refresh, close_requests])
     }
 
     fn handle_runner_message(&mut self, message: RunnerMessage) {
@@ -410,6 +559,7 @@ impl App {
                     }
                     SessionEvent::TransferTerminal(id) => {
                         self.home.remove_active_download(&id);
+                        self.download_records.remove(&id);
                     }
                     SessionEvent::Error(error) => {
                         self.home.add_error(error);
@@ -427,12 +577,135 @@ impl App {
         }
 
         if drained {
+            self.download_records.clear();
+            self.remove_persisted_session();
             if let Some(session) = &mut self.session {
                 session.finish_background();
             }
             self.session = None;
         }
     }
+
+    fn record_accepted_downloads(
+        &mut self,
+        downloads: &[QueuedDownload],
+        existing_handles: &HashSet<String>,
+        accepted_handles: &HashSet<String>,
+    ) {
+        for (handle, record) in records_by_handle(downloads) {
+            if !existing_handles.contains(&handle) && accepted_handles.contains(&handle) {
+                self.download_records.insert(handle, record);
+            }
+        }
+    }
+
+    fn retain_download_records(&mut self, records: Vec<DownloadSessionRecord>) {
+        retain_download_records(&mut self.download_records, records);
+    }
+
+    fn remove_persisted_session(&mut self) {
+        if let Err(error) = session_persistence::remove() {
+            self.error_modal = Some(format!("Failed to remove download session: {error}"));
+        }
+    }
+
+    fn close_window(&mut self) -> Task<Message> {
+        if let Some(session) = &mut self.session {
+            session.abort_background();
+        }
+        self.session = None;
+        window::latest().and_then(window::close)
+    }
+}
+
+fn records_by_handle(downloads: &[QueuedDownload]) -> HashMap<String, DownloadSessionRecord> {
+    downloads
+        .iter()
+        .map(|queued| {
+            (
+                queued.download.node.handle.clone(),
+                DownloadSessionRecord {
+                    source_url: queued.source_url.clone(),
+                    node_handle: queued.download.node.handle.clone(),
+                    destination_dir: queued.download.file_path.clone(),
+                    expected_size: queued.download.node.size,
+                },
+            )
+        })
+        .collect()
+}
+
+fn retain_download_records(
+    download_records: &mut HashMap<String, DownloadSessionRecord>,
+    records: Vec<DownloadSessionRecord>,
+) {
+    for record in records {
+        download_records
+            .entry(record.node_handle.clone())
+            .or_insert(record);
+    }
+}
+
+fn expose_accepted_downloads(
+    home: &mut Home,
+    downloads: &[QueuedDownload],
+    existing_handles: &HashSet<String>,
+    accepted_handles: &HashSet<String>,
+) {
+    for queued in downloads {
+        let handle = &queued.download.node.handle;
+        if !existing_handles.contains(handle) && accepted_handles.contains(handle) {
+            home.add_active_download(queued.download.clone());
+        }
+    }
+}
+
+async fn restore_downloads(mega: MegaClient) -> Result<RestoredDownloads, String> {
+    let records = session_persistence::load().map_err(|error| error.to_string())?;
+    let mut records_by_url: HashMap<String, Vec<DownloadSessionRecord>> = HashMap::new();
+    for record in records {
+        records_by_url
+            .entry(record.source_url.clone())
+            .or_default()
+            .push(record);
+    }
+
+    let mut downloads = Vec::new();
+    let mut retained_records = Vec::new();
+    let mut errors = Vec::new();
+    for (source_url, records) in records_by_url {
+        let nodes = match mega.fetch_public_nodes(&source_url).await {
+            Ok(nodes) => nodes,
+            Err(error) => {
+                errors.push(format!("Failed to restore {source_url}: {error}"));
+                retained_records.extend(records);
+                continue;
+            }
+        };
+        for record in records {
+            let Some(node) = nodes.get(&record.node_handle) else {
+                continue;
+            };
+            if node.kind != NodeKind::File || node.size != record.expected_size {
+                continue;
+            }
+            let file = MegaFile::new(node.clone(), record.destination_dir);
+            let download = Download::restore(&file)
+                .await
+                .map_err(|error| format!("Failed to inspect {}: {error}", node.name))?;
+            if let Some(download) = download {
+                downloads.push(QueuedDownload {
+                    download,
+                    source_url: record.source_url,
+                });
+            }
+        }
+    }
+    Ok(RestoredDownloads {
+        downloads,
+        retained_records,
+        errors,
+    })
 }
 
 fn open_url_in_browser(url: &str) -> Result<(), String> {
@@ -478,4 +751,111 @@ pub(crate) fn build_app() -> iced::Application<impl iced::Program<Message = Mess
         .font(CABIN_REGULAR)
         .font(INCONSOLATA_MEDIUM)
         .default_font(Font::with_name("Cabin"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{expose_accepted_downloads, records_by_handle, retain_download_records};
+    use crate::app::screens::choose_files::QueuedDownload;
+    use crate::app::screens::home::Home;
+    use crate::mega_client::Node;
+    use crate::session_persistence::DownloadSessionRecord;
+    use crate::{Download, MegaFile};
+    use std::collections::{HashMap, HashSet};
+    use std::path::PathBuf;
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn accepted_queue_records_keep_restore_provenance() {
+        let file = MegaFile::new(
+            Node::test_file("A1b2C3", "example-video.mkv", 2_097_152),
+            PathBuf::from("courses/rust"),
+        );
+        let queued = QueuedDownload {
+            download: Download::new(&file),
+            source_url: "https://mega.nz/folder/AbCdEf#trusted-key".to_string(),
+        };
+
+        let records = records_by_handle(&[queued]);
+        let record = records
+            .get("A1b2C3")
+            .expect("record for accepted queue item");
+
+        assert_eq!(
+            record.source_url,
+            "https://mega.nz/folder/AbCdEf#trusted-key"
+        );
+        assert_eq!(record.node_handle, "A1b2C3");
+        assert_eq!(record.destination_dir, PathBuf::from("courses/rust"));
+        assert_eq!(record.expected_size, 2_097_152);
+    }
+
+    #[test]
+    fn failed_restore_records_survive_without_replacing_queued_records() {
+        let mut records = HashMap::from([(
+            "active-handle".to_string(),
+            DownloadSessionRecord {
+                source_url: "https://mega.nz/file/active#key".to_string(),
+                node_handle: "active-handle".to_string(),
+                destination_dir: PathBuf::from("downloads/active"),
+                expected_size: 4_096,
+            },
+        )]);
+
+        retain_download_records(
+            &mut records,
+            vec![
+                DownloadSessionRecord {
+                    source_url: "https://mega.nz/file/stale#key".to_string(),
+                    node_handle: "active-handle".to_string(),
+                    destination_dir: PathBuf::from("downloads/stale"),
+                    expected_size: 4_096,
+                },
+                DownloadSessionRecord {
+                    source_url: "https://mega.nz/folder/retry#key".to_string(),
+                    node_handle: "retry-handle".to_string(),
+                    destination_dir: PathBuf::from("downloads/retry"),
+                    expected_size: 8_192,
+                },
+            ],
+        );
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(
+            records["active-handle"].source_url,
+            "https://mega.nz/file/active#key"
+        );
+        assert_eq!(
+            records["retry-handle"].source_url,
+            "https://mega.nz/folder/retry#key"
+        );
+    }
+
+    #[test]
+    fn accepted_restored_download_is_visible_with_seeded_progress() {
+        let file = MegaFile::new(
+            Node::test_file("restored-handle", "restored.bin", 1_024),
+            PathBuf::from("saved"),
+        );
+        let download = Download::new(&file);
+        download.set_downloaded(256);
+        download.pause();
+        let queued = QueuedDownload {
+            download,
+            source_url: "https://mega.nz/file/restored#key".to_string(),
+        };
+        let mut home = Home::new();
+
+        expose_accepted_downloads(
+            &mut home,
+            &[queued],
+            &HashSet::new(),
+            &HashSet::from(["restored-handle".to_string()]),
+        );
+
+        let visible = &home.active_downloads()["restored-handle"];
+        assert!(visible.is_paused());
+        assert_eq!(visible.downloaded.load(Ordering::Relaxed), 256);
+        assert_eq!(visible.progress(), 0.25);
+    }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -226,11 +226,9 @@ impl App {
                             if let Some(session) = &mut self.session {
                                 session.set_runner_sender(runner_sender);
                                 let existing_handles = session.handles();
-                                let downloads_to_queue: Vec<Download> = downloads
-                                    .iter()
-                                    .map(|queued| queued.download.clone())
-                                    .collect();
-                                if let Err(error) = session.add_downloads(downloads_to_queue) {
+                                if let Err(error) = session.add_downloads(
+                                    downloads.iter().map(|queued| queued.download.clone()),
+                                ) {
                                     self.error_modal =
                                         Some(format!("Failed to queue downloads: {error}"));
                                     return Task::none();
@@ -298,12 +296,12 @@ impl App {
                     let session = self.session.as_mut().expect("session created when absent");
                     session.set_runner_sender(runner_sender);
                     let existing_handles = session.handles();
-                    let downloads_to_queue: Vec<Download> = restored
-                        .downloads
-                        .iter()
-                        .map(|queued| queued.download.clone())
-                        .collect();
-                    match session.add_downloads(downloads_to_queue) {
+                    match session.add_downloads(
+                        restored
+                            .downloads
+                            .iter()
+                            .map(|queued| queued.download.clone()),
+                    ) {
                         Ok(_) => {
                             let accepted_handles = session.handles();
                             self.record_accepted_downloads(
@@ -593,7 +591,7 @@ impl App {
         accepted_handles: &HashSet<String>,
     ) {
         for (handle, record) in records_by_handle(downloads) {
-            if !existing_handles.contains(&handle) && accepted_handles.contains(&handle) {
+            if is_newly_accepted_handle(&handle, existing_handles, accepted_handles) {
                 self.download_records.insert(handle, record);
             }
         }
@@ -654,10 +652,18 @@ fn expose_accepted_downloads(
 ) {
     for queued in downloads {
         let handle = &queued.download.node.handle;
-        if !existing_handles.contains(handle) && accepted_handles.contains(handle) {
+        if is_newly_accepted_handle(handle, existing_handles, accepted_handles) {
             home.add_active_download(queued.download.clone());
         }
     }
+}
+
+fn is_newly_accepted_handle(
+    handle: &str,
+    existing_handles: &HashSet<String>,
+    accepted_handles: &HashSet<String>,
+) -> bool {
+    !existing_handles.contains(handle) && accepted_handles.contains(handle)
 }
 
 async fn restore_downloads(mega: MegaClient) -> Result<RestoredDownloads, String> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,6 +14,7 @@ use iced::time::every;
 use iced::widget::{Row, container, text};
 use iced::{Element, Font, Length, Subscription, Task, Theme, window};
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 use std::process::Command;
 use std::time::Duration;
 use tokio::sync::mpsc::Sender as TokioSender;
@@ -340,7 +341,18 @@ impl App {
                     return self.close_window();
                 }
 
-                let records: Vec<_> = self.download_records.values().cloned().collect();
+                let records = match snapshot_records(
+                    Path::new("download-session.json"),
+                    &self.download_records,
+                ) {
+                    Ok(records) => records,
+                    Err(error) => {
+                        self.close_pending = false;
+                        self.error_modal =
+                            Some(format!("Failed to load download session: {error}"));
+                        return Task::none();
+                    }
+                };
                 Task::perform(
                     async move {
                         if records.is_empty() {
@@ -644,6 +656,27 @@ fn retain_download_records(
     }
 }
 
+fn merge_download_records(
+    records: &mut HashMap<String, DownloadSessionRecord>,
+    additional: impl IntoIterator<Item = DownloadSessionRecord>,
+) {
+    for record in additional {
+        records.entry(record.node_handle.clone()).or_insert(record);
+    }
+}
+
+fn snapshot_records(
+    path: &Path,
+    download_records: &HashMap<String, DownloadSessionRecord>,
+) -> Result<Vec<DownloadSessionRecord>, session_persistence::Error> {
+    let mut records = session_persistence::load_from(path)?
+        .into_iter()
+        .map(|record| (record.node_handle.clone(), record))
+        .collect();
+    merge_download_records(&mut records, download_records.values().cloned());
+    Ok(records.into_values().collect())
+}
+
 fn expose_accepted_downloads(
     home: &mut Home,
     downloads: &[QueuedDownload],
@@ -766,10 +799,10 @@ mod tests {
     use crate::app::screens::choose_files::QueuedDownload;
     use crate::app::screens::home::Home;
     use crate::mega_client::Node;
-    use crate::session_persistence::DownloadSessionRecord;
+    use crate::session_persistence::{self, DownloadSessionRecord};
     use crate::{Download, MegaFile};
     use std::collections::{HashMap, HashSet};
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::sync::atomic::Ordering;
 
     #[test]
@@ -835,6 +868,45 @@ mod tests {
         assert_eq!(
             records["retry-handle"].source_url,
             "https://mega.nz/folder/retry#key"
+        );
+    }
+
+    #[test]
+    fn close_snapshot_selects_persisted_and_queued_records() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let path = temp.path().join("download-session.json");
+        session_persistence::save_to(
+            &path,
+            &[DownloadSessionRecord {
+                source_url: "https://mega.nz/file/restore#key".to_string(),
+                node_handle: "restore-handle".to_string(),
+                destination_dir: PathBuf::from("downloads/restore"),
+                expected_size: 8_192,
+            }],
+        )
+        .expect("save persisted restore record");
+        let records = HashMap::from([(
+            "queued-handle".to_string(),
+            DownloadSessionRecord {
+                source_url: "https://mega.nz/file/queued#key".to_string(),
+                node_handle: "queued-handle".to_string(),
+                destination_dir: PathBuf::from("downloads/queued"),
+                expected_size: 4_096,
+            },
+        )]);
+
+        let selected = super::snapshot_records(Path::new(&path), &records)
+            .expect("select close snapshot records");
+        let selected: HashMap<_, _> = selected
+            .into_iter()
+            .map(|record| (record.node_handle.clone(), record))
+            .collect();
+
+        assert_eq!(selected.len(), 2);
+        assert_eq!(selected["restore-handle"].expected_size, 8_192);
+        assert_eq!(
+            selected["queued-handle"].source_url,
+            "https://mega.nz/file/queued#key"
         );
     }
 

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -26,6 +26,9 @@ pub(crate) enum Message {
     RunnerBatch(Vec<RunnerMessage>),
     /// runner subscription is ready, provides sender for workers
     RunnerReady(Sender<RunnerMessage>),
+    CloseRequested,
+    CloseSnapshotFinished(Result<(), String>),
+    RestoreFinished(Result<crate::app::RestoredDownloads, String>),
     /// navigate to a different route
     Navigate(Route),
     /// close the error modal

--- a/src/app/screens/choose_files.rs
+++ b/src/app/screens/choose_files.rs
@@ -1,4 +1,5 @@
 use crate::app::MONOSPACE;
+use crate::app::screens::import::ImportedFiles;
 use crate::app::screens::{COLLAPSE_ICON, EXPAND_ICON};
 use crate::mega_client::NodeKind;
 use crate::{Download, MegaFile, app::styles};
@@ -8,7 +9,7 @@ use iced::{Element, Length, Theme};
 use std::collections::{HashMap, HashSet};
 
 pub(crate) struct ChooseFiles {
-    files: Vec<MegaFile>,
+    files: Vec<ImportedFiles>,
     file_filter: HashMap<String, bool>,
     expanded_files: HashMap<String, bool>,
 }
@@ -27,13 +28,19 @@ pub(crate) enum Message {
 
 pub(crate) enum Action {
     None,
-    QueueDownloads(Vec<Download>),
+    QueueDownloads(Vec<QueuedDownload>),
     /// notify parent to clear file handles tracking
     ClearFiles,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct QueuedDownload {
+    pub(crate) download: Download,
+    pub(crate) source_url: String,
+}
+
 impl ChooseFiles {
-    pub(crate) fn new(files: Vec<MegaFile>) -> Self {
+    pub(crate) fn new(files: Vec<ImportedFiles>) -> Self {
         Self {
             files,
             file_filter: HashMap::new(),
@@ -41,7 +48,7 @@ impl ChooseFiles {
         }
     }
 
-    pub(crate) fn add_files(&mut self, files: Vec<MegaFile>) {
+    pub(crate) fn add_files(&mut self, files: Vec<ImportedFiles>) {
         self.files.extend(files);
     }
 
@@ -71,14 +78,22 @@ impl ChooseFiles {
             }
             Message::AddFiles => {
                 // flatten file structure into a list of downloads
-                let downloads: Vec<Download> = self
+                let downloads: Vec<QueuedDownload> = self
                     .files
                     .iter()
-                    .flat_map(|file| file.iter())
-                    .filter(|f| f.node.kind == NodeKind::File)
-                    .filter(|f| *self.file_filter.get(&f.node.handle).unwrap_or(&true))
-                    .filter(|f| !active_handles.contains(&f.node.handle))
-                    .map(Download::new)
+                    .flat_map(|imported| {
+                        imported
+                            .files
+                            .iter()
+                            .flat_map(|file| file.iter().map(|file| (file, &imported.source_url)))
+                    })
+                    .filter(|(file, _)| file.node.kind == NodeKind::File)
+                    .filter(|(file, _)| *self.file_filter.get(&file.node.handle).unwrap_or(&true))
+                    .filter(|(file, _)| !active_handles.contains(&file.node.handle))
+                    .map(|(file, source_url)| QueuedDownload {
+                        download: Download::new(file),
+                        source_url: source_url.clone(),
+                    })
                     .collect();
 
                 Action::QueueDownloads(downloads)
@@ -93,15 +108,17 @@ impl ChooseFiles {
         let size: u64 = self
             .files
             .iter()
-            .flat_map(|file| file.iter())
+            .flat_map(|imported| imported.files.iter().flat_map(|file| file.iter()))
             .filter(|f| f.node.kind == NodeKind::File)
             .filter(|f| *self.file_filter.get(&f.node.handle).unwrap_or(&true))
             .map(|file| file.node.size)
             .sum();
         let size_gb = size as f64 / 1024f64.powi(3);
 
-        for file in &self.files {
-            column = column.push(self.recursive_files(file));
+        for imported in &self.files {
+            for file in &imported.files {
+                column = column.push(self.recursive_files(file));
+            }
         }
 
         container(

--- a/src/app/screens/home.rs
+++ b/src/app/screens/home.rs
@@ -10,7 +10,6 @@ use std::sync::atomic::Ordering::Relaxed;
 pub(crate) struct Home {
     active_downloads: HashMap<String, Download>,
     errors: Vec<String>,
-    all_paused: bool,
     bandwidth_counter: usize,
 }
 
@@ -34,7 +33,6 @@ impl Home {
         Self {
             active_downloads: HashMap::new(),
             errors: Vec::new(),
-            all_paused: false,
             bandwidth_counter: 0,
         }
     }
@@ -82,7 +80,6 @@ impl Home {
                 Action::None
             }
             Message::PauseDownloads => {
-                self.all_paused = true;
                 for download in self.active_downloads.values() {
                     download.pause();
                 }
@@ -95,19 +92,25 @@ impl Home {
                 Action::None
             }
             Message::ResumeDownloads => {
-                self.all_paused = false;
                 for download in self.active_downloads.values() {
                     download.resume();
                 }
                 Action::None
             }
             Message::ResumeDownload(id) => {
-                self.all_paused = false; // can't be all paused if resuming one
                 if let Some(download) = self.active_downloads.get(&id) {
                     download.resume();
                 }
                 Action::None
             }
+        }
+    }
+
+    fn bulk_control_message(&self) -> Message {
+        if self.active_downloads.values().all(Download::is_paused) {
+            Message::ResumeDownloads
+        } else {
+            Message::PauseDownloads
         }
     }
 
@@ -143,15 +146,17 @@ impl Home {
                     .spacing(10)
                     .padding(8)
                     .height(Length::Fixed(45_f32))
-                    .push(if self.all_paused {
-                        button(" Resume All ")
-                            .on_press(Message::ResumeDownloads)
-                            .style(styles::button::primary)
-                    } else {
-                        button(" Pause All ")
-                            .on_press(Message::PauseDownloads)
-                            .style(styles::button::primary)
-                    })
+                    .push(
+                        if matches!(self.bulk_control_message(), Message::ResumeDownloads) {
+                            button(" Resume All ")
+                                .on_press(Message::ResumeDownloads)
+                                .style(styles::button::primary)
+                        } else {
+                            button(" Pause All ")
+                                .on_press(Message::PauseDownloads)
+                                .style(styles::button::primary)
+                        },
+                    )
                     .push(
                         button(" Cancel All ")
                             .on_press(Message::CancelDownloads)
@@ -222,3 +227,6 @@ impl Home {
         column.into()
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/app/screens/home/tests.rs
+++ b/src/app/screens/home/tests.rs
@@ -1,0 +1,70 @@
+use super::{Home, Message};
+use crate::mega_client::Node;
+use crate::{Download, MegaFile};
+use std::path::PathBuf;
+
+#[test]
+fn bulk_control_resumes_when_all_visible_downloads_are_paused() {
+    let first_file = MegaFile::new(
+        Node::test_file("paused-first", "first.bin", 1_024),
+        PathBuf::from("downloads"),
+    );
+    let second_file = MegaFile::new(
+        Node::test_file("paused-second", "second.bin", 2_048),
+        PathBuf::from("downloads"),
+    );
+    let first_download = Download::new(&first_file);
+    let second_download = Download::new(&second_file);
+    first_download.pause();
+    second_download.pause();
+    let mut home = Home::new();
+    home.add_active_download(first_download);
+    home.add_active_download(second_download);
+
+    assert!(matches!(
+        home.bulk_control_message(),
+        Message::ResumeDownloads
+    ));
+}
+
+#[test]
+fn bulk_control_pauses_when_all_visible_downloads_are_running() {
+    let first_file = MegaFile::new(
+        Node::test_file("running-first", "first.bin", 1_024),
+        PathBuf::from("downloads"),
+    );
+    let second_file = MegaFile::new(
+        Node::test_file("running-second", "second.bin", 2_048),
+        PathBuf::from("downloads"),
+    );
+    let mut home = Home::new();
+    home.add_active_download(Download::new(&first_file));
+    home.add_active_download(Download::new(&second_file));
+
+    assert!(matches!(
+        home.bulk_control_message(),
+        Message::PauseDownloads
+    ));
+}
+
+#[test]
+fn bulk_control_pauses_when_visible_downloads_are_mixed() {
+    let paused_file = MegaFile::new(
+        Node::test_file("paused", "paused.bin", 1_024),
+        PathBuf::from("downloads"),
+    );
+    let running_file = MegaFile::new(
+        Node::test_file("running", "running.bin", 2_048),
+        PathBuf::from("downloads"),
+    );
+    let paused_download = Download::new(&paused_file);
+    paused_download.pause();
+    let mut home = Home::new();
+    home.add_active_download(paused_download);
+    home.add_active_download(Download::new(&running_file));
+
+    assert!(matches!(
+        home.bulk_control_message(),
+        Message::PauseDownloads
+    ));
+}

--- a/src/app/screens/import.rs
+++ b/src/app/screens/import.rs
@@ -20,7 +20,7 @@ pub(crate) enum Message {
     /// load all URLs
     AddAllUrls,
     /// file loading result
-    GotFiles(Result<(Vec<MegaFile>, usize), usize>),
+    GotFiles(Result<(Vec<MegaFile>, String, usize), usize>),
     /// URL text input changed
     UrlInput((usize, String)),
     /// add new URL input field
@@ -32,8 +32,13 @@ pub(crate) enum Message {
 pub(crate) enum Action {
     None,
     Run(Task<Message>),
-    FilesLoaded(Vec<MegaFile>),
+    FilesLoaded(ImportedFiles),
     ShowError(String),
+}
+
+pub(crate) struct ImportedFiles {
+    pub(crate) files: Vec<MegaFile>,
+    pub(crate) source_url: String,
 }
 
 pub(crate) struct Import {
@@ -91,10 +96,15 @@ impl Import {
                             UrlStatus::Loading | UrlStatus::Loaded => Action::None,
                             _ => {
                                 input.status = UrlStatus::Loading; // set status to loading
+                                let mega = MegaClient::clone(mega);
                                 let url = input.value.clone();
+                                let source_url = url.clone();
 
                                 Action::Run(Task::perform(
-                                    get_files(mega.clone(), url, index),
+                                    async move {
+                                        let (files, index) = get_files(mega, url, index).await?;
+                                        Ok((files, source_url, index))
+                                    },
                                     Message::GotFiles,
                                 ))
                             }
@@ -116,10 +126,10 @@ impl Import {
                 Action::Run(Task::batch(commands))
             }
             Message::GotFiles(result) => match result {
-                Ok((files, index)) => {
+                Ok((files, source_url, index)) => {
                     if let Some(input) = self.url_input.get_mut(index) {
                         input.status = UrlStatus::Loaded;
-                        Action::FilesLoaded(files)
+                        Action::FilesLoaded(ImportedFiles { files, source_url })
                     } else {
                         Action::ShowError("An error occurred".to_string())
                     }

--- a/src/app/screens/settings.rs
+++ b/src/app/screens/settings.rs
@@ -38,6 +38,7 @@ pub(crate) enum Message {
     RemoveProxy(usize),
     RebuildMega,
     CheckForUpdatesChanged(bool),
+    PersistDownloadSessionsChanged(bool),
     CheckForUpdates,
 }
 
@@ -150,6 +151,10 @@ impl Settings {
             }
             Message::CheckForUpdatesChanged(check_for_updates) => {
                 self.config.check_for_updates = check_for_updates;
+                Action::None
+            }
+            Message::PersistDownloadSessionsChanged(enabled) => {
+                self.config.persist_download_sessions = enabled;
                 Action::None
             }
             Message::ProxyModeChanged(proxy_mode) => {
@@ -291,6 +296,17 @@ impl Settings {
                 ))
                 .push(space::vertical().height(Length::Fixed(10_f32)))
                 .push(self.proxy_selector())
+                .push(space::vertical().height(Length::Fixed(8_f32)))
+                .push(
+                    Row::new()
+                        .height(Length::Fixed(30_f32))
+                        .push(space::horizontal().width(Length::Fixed(8_f32)))
+                        .push(
+                            checkbox(self.config.persist_download_sessions)
+                                .label("Restore downloads after closing")
+                                .on_toggle(Message::PersistDownloadSessionsChanged),
+                        ),
+                )
                 .push(space::vertical().height(Length::Fixed(8_f32)))
                 .push(
                     Row::new()
@@ -463,5 +479,23 @@ impl Settings {
             .push(space::horizontal().width(Length::Fixed(8_f32)))
             .push(column)
             .into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Action, Message, Settings};
+    use crate::config::Config;
+
+    #[test]
+    fn download_session_restore_is_disabled_by_default_and_toggleable() {
+        let mut settings = Settings::new(Config::default());
+
+        assert!(!settings.config.persist_download_sessions);
+        assert!(matches!(
+            settings.update(Message::PersistDownloadSessionsChanged(true)),
+            Action::None
+        ));
+        assert!(settings.config.persist_download_sessions);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,6 +64,9 @@ pub(crate) struct Config {
     #[cfg(feature = "gui")]
     #[serde(default = "default_check_for_updates")]
     pub(crate) check_for_updates: bool,
+    #[cfg(feature = "gui")]
+    #[serde(default)]
+    pub(crate) persist_download_sessions: bool,
     pub(crate) max_workers: usize,
     pub(crate) concurrency_budget: usize,
     pub(crate) max_retries: u32,
@@ -82,6 +85,8 @@ impl Default for Config {
             theme: "Vanilla".to_string(),
             #[cfg(feature = "gui")]
             check_for_updates: default_check_for_updates(),
+            #[cfg(feature = "gui")]
+            persist_download_sessions: false,
             max_workers: 10,
             concurrency_budget: 10,
             max_retries: 3,

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod app;
 mod cli;
 mod config;
 mod session;
+mod session_persistence;
 #[cfg(feature = "gui")]
 mod update_check;
 mod worker;

--- a/src/session.rs
+++ b/src/session.rs
@@ -239,12 +239,13 @@ impl WorkerState {
 mod tests {
     use super::{SessionEvent, TransferSession};
     use crate::config::Config;
-    use crate::worker::RunnerMessage;
     use crate::worker::fake::{DriverAction, FakeDriver};
     use crate::worker::tests::{
         make_download, next_message, wait_for_driver_calls, wait_for_paused,
     };
+    use crate::worker::{Download, RunnerMessage};
     use std::collections::VecDeque;
+    use std::sync::atomic::Ordering;
     use std::time::Duration;
     use tempfile::TempDir;
     use tokio::sync::mpsc::channel;
@@ -431,6 +432,68 @@ mod tests {
         .await
         .expect("session drain timeout");
 
+        assert!(!session.has_live_transfers());
+        session.finish().await;
+    }
+
+    #[tokio::test]
+    async fn test_pausing_before_queueing_keeps_restored_download_paused() {
+        let temp = TempDir::new().expect("temp dir");
+        let node = crate::mega_client::Node::test_file(
+            "handle-restored-video.mkv",
+            "restored-video.mkv",
+            2_097_152,
+        );
+        let file = crate::MegaFile::new(node, temp.path().to_path_buf());
+        tokio::fs::write(
+            temp.path().join("restored-video.mkv.partial"),
+            vec![0_u8; 524_288],
+        )
+        .await
+        .expect("write durable partial");
+        let download = Download::restore(&file)
+            .await
+            .expect("inspect restored download")
+            .expect("final file must not exist");
+        let driver = make_driver(vec![DriverAction::Complete]);
+        let (runner_sender, mut runner_receiver) = channel(64);
+        let mut session = TransferSession::new(driver.clone(), Config::default());
+        session.set_runner_sender(runner_sender);
+
+        assert_eq!(download.downloaded.load(Ordering::Relaxed), 524_288);
+        #[cfg(feature = "gui")]
+        assert_eq!(download.progress(), 0.25);
+
+        session
+            .add_downloads(vec![download.clone()])
+            .expect("queue paused restored download");
+
+        wait_for_paused(&download).await;
+        sleep(Duration::from_millis(150)).await;
+        assert!(download.is_paused());
+        assert!(session.has_live_transfers());
+        assert_eq!(session.active_count(), 0);
+        assert_eq!(session.pending_count(), 1);
+        assert_eq!(driver.call_count(), 0);
+        assert!(
+            runner_receiver.try_recv().is_err(),
+            "paused restored download became active before resume"
+        );
+
+        download.resume();
+
+        let events = session.handle_runner_message(next_message(&mut runner_receiver).await);
+        assert!(matches!(
+            events.as_slice(),
+            [SessionEvent::TransferActive(_)]
+        ));
+        let events = session.handle_runner_message(next_message(&mut runner_receiver).await);
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, SessionEvent::Drained))
+        );
+        assert_eq!(driver.call_count(), 1);
         assert!(!session.has_live_transfers());
         session.finish().await;
     }

--- a/src/session_persistence.rs
+++ b/src/session_persistence.rs
@@ -57,6 +57,12 @@ struct SessionFile {
     records: Vec<DownloadSessionRecord>,
 }
 
+#[derive(Serialize)]
+struct SessionFileRef<'a> {
+    version: u32,
+    records: &'a [DownloadSessionRecord],
+}
+
 pub(crate) fn load() -> Result<Vec<DownloadSessionRecord>> {
     load_from(Path::new(SESSION_PATH))
 }
@@ -109,9 +115,9 @@ fn extract_version(path: &Path) -> Option<u32> {
 }
 
 fn save_to(path: &Path, records: &[DownloadSessionRecord]) -> Result<()> {
-    let contents = serde_json::to_vec_pretty(&SessionFile {
+    let contents = serde_json::to_vec_pretty(&SessionFileRef {
         version: FORMAT_VERSION,
-        records: records.to_vec(),
+        records,
     })?;
     let temporary_path = temporary_path(path);
     let result = (|| {
@@ -166,7 +172,7 @@ fn replace_file(temporary_path: &Path, path: &Path) -> io::Result<()> {
         ) -> i32;
     }
 
-    let target_exists = path_exists(path)?;
+    let target_exists = path.try_exists()?;
     let temporary_path: Vec<u16> = temporary_path
         .as_os_str()
         .encode_wide()
@@ -198,15 +204,6 @@ fn replace_file(temporary_path: &Path, path: &Path) -> io::Result<()> {
         Err(io::Error::last_os_error())
     } else {
         Ok(())
-    }
-}
-
-#[cfg(windows)]
-fn path_exists(path: &Path) -> io::Result<bool> {
-    match fs::metadata(path) {
-        Ok(_) => Ok(true),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
-        Err(error) => Err(error),
     }
 }
 

--- a/src/session_persistence.rs
+++ b/src/session_persistence.rs
@@ -1,0 +1,347 @@
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const SESSION_PATH: &str = "download-session.json";
+const FORMAT_VERSION: u32 = 1;
+
+type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug)]
+pub(crate) enum Error {
+    Io(io::Error),
+    Json(serde_json::Error),
+    UnsupportedVersion(u32),
+}
+
+impl From<io::Error> for Error {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "IO error: {error}"),
+            Self::Json(error) => write!(f, "JSON error: {error}"),
+            Self::UnsupportedVersion(version) => {
+                write!(f, "unsupported download-session version: {version}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct DownloadSessionRecord {
+    pub(crate) source_url: String,
+    pub(crate) node_handle: String,
+    pub(crate) destination_dir: PathBuf,
+    pub(crate) expected_size: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SessionFile {
+    version: u32,
+    records: Vec<DownloadSessionRecord>,
+}
+
+pub(crate) fn load() -> Result<Vec<DownloadSessionRecord>> {
+    load_from(Path::new(SESSION_PATH))
+}
+
+pub(crate) fn save(records: &[DownloadSessionRecord]) -> Result<()> {
+    save_to(Path::new(SESSION_PATH), records)
+}
+
+pub(crate) fn remove() -> Result<()> {
+    remove_from(Path::new(SESSION_PATH))
+}
+
+fn load_from(path: &Path) -> Result<Vec<DownloadSessionRecord>> {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error.into()),
+    };
+
+    let parsed = serde_json::from_reader::<_, SessionFile>(file).and_then(|file| {
+        if file.version != FORMAT_VERSION {
+            return Err(serde_json::Error::io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported version {}", file.version),
+            )));
+        }
+        Ok(file.records)
+    });
+
+    match parsed {
+        Ok(records) => Ok(records),
+        Err(error) => {
+            let backup = backup_path(path);
+            fs::copy(path, &backup)?;
+            if let Some(version) = extract_version(path) {
+                return Err(Error::UnsupportedVersion(version));
+            }
+            Err(error.into())
+        }
+    }
+}
+
+fn extract_version(path: &Path) -> Option<u32> {
+    let file = File::open(path).ok()?;
+    let value: serde_json::Value = serde_json::from_reader(file).ok()?;
+    let version = value.get("version")?.as_u64()?;
+    u32::try_from(version)
+        .ok()
+        .filter(|version| *version != FORMAT_VERSION)
+}
+
+fn save_to(path: &Path, records: &[DownloadSessionRecord]) -> Result<()> {
+    let contents = serde_json::to_vec_pretty(&SessionFile {
+        version: FORMAT_VERSION,
+        records: records.to_vec(),
+    })?;
+    let temporary_path = temporary_path(path);
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary_path)?;
+        file.write_all(&contents)?;
+        #[cfg(unix)]
+        if let Ok(metadata) = fs::metadata(path) {
+            file.set_permissions(metadata.permissions())?;
+        }
+        file.sync_all()?;
+        replace_file(&temporary_path, path)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary_path);
+    }
+    result
+}
+
+#[cfg(not(windows))]
+fn replace_file(temporary_path: &Path, path: &Path) -> io::Result<()> {
+    fs::rename(temporary_path, path)
+}
+
+#[cfg(windows)]
+fn replace_file(temporary_path: &Path, path: &Path) -> io::Result<()> {
+    use std::ffi::c_void;
+    use std::os::windows::ffi::OsStrExt;
+    use std::ptr;
+
+    const REPLACEFILE_WRITE_THROUGH: u32 = 0x00000001;
+    const MOVEFILE_REPLACE_EXISTING: u32 = 0x00000001;
+    const MOVEFILE_WRITE_THROUGH: u32 = 0x00000008;
+
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        fn ReplaceFileW(
+            replaced_file_name: *const u16,
+            replacement_file_name: *const u16,
+            backup_file_name: *const u16,
+            replace_flags: u32,
+            exclude: *mut c_void,
+            reserved: *mut c_void,
+        ) -> i32;
+        fn MoveFileExW(
+            existing_file_name: *const u16,
+            new_file_name: *const u16,
+            flags: u32,
+        ) -> i32;
+    }
+
+    let target_exists = path_exists(path)?;
+    let temporary_path: Vec<u16> = temporary_path
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+    let path: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+    let replaced = if target_exists {
+        unsafe {
+            ReplaceFileW(
+                path.as_ptr(),
+                temporary_path.as_ptr(),
+                ptr::null(),
+                REPLACEFILE_WRITE_THROUGH,
+                ptr::null_mut(),
+                ptr::null_mut(),
+            )
+        }
+    } else {
+        unsafe {
+            MoveFileExW(
+                temporary_path.as_ptr(),
+                path.as_ptr(),
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            )
+        }
+    };
+
+    if replaced == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn path_exists(path: &Path) -> io::Result<bool> {
+    match fs::metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+fn remove_from(path: &Path) -> Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn temporary_path(path: &Path) -> PathBuf {
+    path.with_file_name(format!(
+        ".{}.tmp.{}.{}",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("session"),
+        std::process::id(),
+        timestamp_nanos()
+    ))
+}
+
+fn backup_path(path: &Path) -> PathBuf {
+    path.with_file_name(format!(
+        "{}.backup.{}",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("session"),
+        timestamp_nanos()
+    ))
+}
+
+fn timestamp_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn record() -> DownloadSessionRecord {
+        DownloadSessionRecord {
+            source_url: "https://mega.nz/file/example#key".to_string(),
+            node_handle: "node-handle".to_string(),
+            destination_dir: PathBuf::from("downloads/2026"),
+            expected_size: 42,
+        }
+    }
+
+    #[test]
+    fn save_and_load_round_trip_only_safe_fields() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().join(SESSION_PATH);
+        let records = vec![record()];
+
+        save_to(&path, &records).expect("save session");
+
+        assert_eq!(load_from(&path).expect("load session"), records);
+        let json = std::fs::read_to_string(path).expect("read session");
+        assert!(json.contains("\"version\": 1"));
+        assert!(!json.contains("progress"));
+        assert!(!json.contains("crypto"));
+    }
+
+    #[test]
+    fn saving_replaces_an_existing_session_file() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().join(SESSION_PATH);
+        let mut replacement = record();
+        replacement.node_handle = "replacement-node-handle".to_string();
+        replacement.destination_dir = PathBuf::from("downloads/restored");
+
+        save_to(&path, &[record()]).expect("save initial session");
+        save_to(&path, &[replacement.clone()]).expect("replace existing session");
+
+        assert_eq!(
+            load_from(&path).expect("load replacement session"),
+            vec![replacement]
+        );
+        assert_eq!(
+            std::fs::read_dir(temp.path())
+                .expect("read session directory")
+                .count(),
+            1,
+            "successful replacement must not leave temporary files"
+        );
+    }
+
+    #[test]
+    fn missing_session_loads_empty_and_remove_is_idempotent() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().join(SESSION_PATH);
+
+        assert!(load_from(&path).expect("load missing session").is_empty());
+        remove_from(&path).expect("remove missing session");
+    }
+
+    #[test]
+    fn corrupt_session_is_backed_up_before_error() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().join(SESSION_PATH);
+        std::fs::write(&path, b"not json").expect("write corrupt session");
+
+        assert!(matches!(load_from(&path), Err(Error::Json(_))));
+        let backups: Vec<_> = std::fs::read_dir(temp.path())
+            .expect("read temp dir")
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_name().to_string_lossy().contains(".backup."))
+            .collect();
+        assert_eq!(backups.len(), 1);
+        assert_eq!(
+            std::fs::read(backups[0].path()).expect("read backup"),
+            b"not json"
+        );
+    }
+
+    #[test]
+    fn unknown_version_is_backed_up_before_error() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().join(SESSION_PATH);
+        std::fs::write(&path, br#"{"version":99,"records":[]}"#).expect("write unknown version");
+
+        assert!(matches!(
+            load_from(&path),
+            Err(Error::UnsupportedVersion(99))
+        ));
+        assert!(
+            std::fs::read_dir(temp.path())
+                .expect("read temp dir")
+                .filter_map(|entry| entry.ok())
+                .any(|entry| entry.file_name().to_string_lossy().contains(".backup."))
+        );
+    }
+}

--- a/src/session_persistence.rs
+++ b/src/session_persistence.rs
@@ -75,7 +75,7 @@ pub(crate) fn remove() -> Result<()> {
     remove_from(Path::new(SESSION_PATH))
 }
 
-fn load_from(path: &Path) -> Result<Vec<DownloadSessionRecord>> {
+pub(crate) fn load_from(path: &Path) -> Result<Vec<DownloadSessionRecord>> {
     let file = match File::open(path) {
         Ok(file) => file,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
@@ -114,17 +114,22 @@ fn extract_version(path: &Path) -> Option<u32> {
         .filter(|version| *version != FORMAT_VERSION)
 }
 
-fn save_to(path: &Path, records: &[DownloadSessionRecord]) -> Result<()> {
+pub(crate) fn save_to(path: &Path, records: &[DownloadSessionRecord]) -> Result<()> {
     let contents = serde_json::to_vec_pretty(&SessionFileRef {
         version: FORMAT_VERSION,
         records,
     })?;
     let temporary_path = temporary_path(path);
     let result = (|| {
-        let mut file = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&temporary_path)?;
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+
+            options.mode(0o600);
+        }
+        let mut file = options.open(&temporary_path)?;
         file.write_all(&contents)?;
         #[cfg(unix)]
         if let Ok(metadata) = fs::metadata(path) {
@@ -270,6 +275,26 @@ mod tests {
         assert!(json.contains("\"version\": 1"));
         assert!(!json.contains("progress"));
         assert!(!json.contains("crypto"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn newly_created_session_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().join(SESSION_PATH);
+
+        save_to(&path, &[record()]).expect("save session");
+
+        assert_eq!(
+            std::fs::metadata(path)
+                .expect("session metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
     }
 
     #[test]

--- a/src/worker/mega_client.rs
+++ b/src/worker/mega_client.rs
@@ -20,7 +20,6 @@ use std::io::SeekFrom;
 use std::ops::ControlFlow;
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::atomic::Ordering::Relaxed;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::fs::OpenOptions;
 use tokio::io::{AsyncSeekExt, AsyncWriteExt};
@@ -152,7 +151,7 @@ impl MegaClient {
         let (download_url, remote_size) = self.get_download_url(&download.node).await?;
 
         // figure out resume offset & open file accordingly
-        let (mut file, resume_from) = if dest_path.exists() {
+        let (mut file, resume_from, durable_len) = if dest_path.exists() {
             let meta = fs::metadata(dest_path)
                 .await
                 .with_context(|| format!("stat {:?}", dest_path))?;
@@ -165,9 +164,11 @@ impl MegaClient {
                         .await
                         .with_context(|| format!("creating {:?}", dest_path))?,
                     0,
+                    0,
                 )
             } else if local_len >= remote_size {
                 // already complete or bigger than the remote size; assume done
+                download.set_downloaded(remote_size);
                 return Ok(true);
             } else {
                 // resume with some rewind.
@@ -184,7 +185,7 @@ impl MegaClient {
                     .await
                     .with_context(|| format!("seeking {:?}", dest_path))?;
 
-                (f, resume_from)
+                (f, resume_from, local_len)
             }
         } else {
             (
@@ -192,8 +193,10 @@ impl MegaClient {
                     .await
                     .with_context(|| format!("creating {:?}", dest_path))?,
                 0,
+                0,
             )
         };
+        download.set_downloaded(durable_len);
 
         // fetch the download response, handling pausing
         let mut req = self.http.get(&download_url);
@@ -229,6 +232,7 @@ impl MegaClient {
         }
         let mut ctr = Ctr128BE::<Aes128>::new((&download.node.aes_key).into(), (&iv_block).into());
         ctr.seek(resume_from);
+        let mut written_through = resume_from;
 
         loop {
             select! {
@@ -243,7 +247,8 @@ impl MegaClient {
                         let mut buf = chunk?.to_vec();
                         ctr.apply_keystream(&mut buf);
                         file.write_all(&buf).await?;
-                        download.downloaded.fetch_add(buf.len(), Relaxed);
+                        written_through = written_through.saturating_add(buf.len() as u64);
+                        download.set_downloaded(durable_len.max(written_through));
                     } else {
                         break;
                     }

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -5,11 +5,12 @@ use log::error;
 use std::error::Error;
 use std::fmt;
 use std::future::Future;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use std::time::Duration;
-use tokio::fs::{create_dir_all, rename, try_exists};
+use tokio::fs::{create_dir_all, metadata, rename, try_exists};
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{Mutex, RwLock, Semaphore, watch};
 use tokio::time::{Instant, sleep};
@@ -50,6 +51,45 @@ impl Download {
             retries: Default::default(),
             last_tried_at: Default::default(),
         }
+    }
+
+    pub(crate) async fn restore(file: &MegaFile) -> io::Result<Option<Self>> {
+        let download = Self::new(file);
+        download.pause();
+
+        match metadata(download.final_path()).await {
+            Ok(_) => return Ok(None),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+
+        let completed = match metadata(download.partial_path()).await {
+            Ok(metadata) if metadata.is_file() => metadata.len(),
+            Ok(_) => 0,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => 0,
+            Err(error) => return Err(error),
+        };
+        download.set_downloaded(completed);
+
+        Ok(Some(download))
+    }
+
+    fn destination_path(&self) -> PathBuf {
+        Path::new("downloads").join(&self.file_path)
+    }
+
+    fn partial_path(&self) -> PathBuf {
+        self.destination_path()
+            .join(format!("{}.partial", self.node.name))
+    }
+
+    fn final_path(&self) -> PathBuf {
+        self.destination_path().join(&self.node.name)
+    }
+
+    pub(crate) fn set_downloaded(&self, completed: u64) {
+        let completed = usize::try_from(completed.min(self.node.size)).unwrap_or(usize::MAX);
+        self.downloaded.store(completed, Ordering::Relaxed);
     }
 }
 
@@ -258,6 +298,16 @@ pub(crate) async fn worker<D: DownloadDriver>(
                     continue;
                 }
 
+                if download.mark_paused_if_requested() {
+                    select! {
+                        _ = cancellation_token.cancelled() => break,
+                        _ = download.stop.cancelled() => continue,
+                        _ = sleep(Duration::from_millis(10)) => (),
+                    }
+                    download_sender.send(download).await?;
+                    continue;
+                }
+
                 let since_last_retry = download.last_tried_at.lock().await.as_ref().map(|i| i.elapsed());
                 if let Some(elapsed) = since_last_retry {
                     let retries = download.retries.load(Ordering::Relaxed);
@@ -298,14 +348,14 @@ pub(crate) async fn worker<D: DownloadDriver>(
                 }
 
                 // create file path for the node
-                let file_path = Path::new("downloads").join(&download.file_path);
+                let file_path = download.destination_path();
                 // create folders if needed
                 create_dir_all(&file_path).await?;
 
                 // full file path to partial file
-                let partial_path = file_path.join(format!("{}.partial", download.node.name));
+                let partial_path = download.partial_path();
                 // full path to final destination
-                let full_path = file_path.join(&download.node.name);
+                let full_path = download.final_path();
                 // this download is already complete
                 if try_exists(&full_path).await? {
                     // report as Inactive to help CLI track completion

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -57,10 +57,8 @@ impl Download {
         let download = Self::new(file);
         download.pause();
 
-        match metadata(download.final_path()).await {
-            Ok(_) => return Ok(None),
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-            Err(error) => return Err(error),
+        if try_exists(download.final_path()).await? {
+            return Ok(None);
         }
 
         let completed = match metadata(download.partial_path()).await {

--- a/src/worker/tests.rs
+++ b/src/worker/tests.rs
@@ -468,6 +468,10 @@ async fn test_real_mega_client_pause_during_send_and_stream_then_resume_and_comp
         fixture_state.saw_non_zero_range.load(Ordering::SeqCst),
         "expected resumed GET request with non-zero Range offset"
     );
+    assert_eq!(
+        download.downloaded.load(Ordering::Relaxed),
+        expected_plain.len()
+    );
 
     cancel.cancel();
     for worker in workers {
@@ -479,6 +483,37 @@ async fn test_real_mega_client_pause_during_send_and_stream_then_resume_and_comp
         .await
         .expect("fixture task join timeout")
         .expect("fixture task join failure");
+}
+
+#[tokio::test]
+async fn test_restore_uses_bounded_partial_length_and_ignores_final_file() {
+    let temp = TempDir::new().expect("temp dir");
+    let node = Node::test_file("restore-handle", "archive.bin", 1_000);
+    let file = MegaFile::new(node, temp.path().to_path_buf());
+    let partial_path = temp.path().join("archive.bin.partial");
+    tokio::fs::write(&partial_path, vec![0_u8; 1_200])
+        .await
+        .expect("write oversized partial");
+
+    let restored = Download::restore(&file)
+        .await
+        .expect("inspect partial")
+        .expect("final file must not exist");
+
+    assert!(restored.is_paused());
+    assert_eq!(restored.downloaded.load(Ordering::Relaxed), 1_000);
+    #[cfg(feature = "gui")]
+    assert_eq!(restored.progress(), 1.0);
+
+    tokio::fs::write(temp.path().join("archive.bin"), b"complete")
+        .await
+        .expect("write final file");
+    assert!(
+        Download::restore(&file)
+            .await
+            .expect("inspect final file")
+            .is_none()
+    );
 }
 
 #[tokio::test]
@@ -744,6 +779,56 @@ async fn test_pause_and_resume() {
         next_message(&mut message_receiver).await,
         RunnerMessage::Inactive { .. }
     ));
+
+    cancel.cancel();
+    for worker in workers {
+        worker.await.expect("worker join").expect("worker result");
+    }
+}
+
+#[tokio::test]
+async fn test_download_paused_before_enqueue_waits_for_explicit_resume() {
+    let temp = TempDir::new().expect("temp dir");
+    let download = make_download("restored-paused.bin", 1024, temp.path().to_path_buf());
+    download.pause();
+    let driver = make_driver(vec![DriverAction::Complete]);
+    let (download_sender, download_receiver) = kanal::unbounded_async();
+    let (message_sender, mut message_receiver) = channel(32);
+    let cancel = CancellationToken::new();
+    let workers = spawn_workers(
+        driver.clone(),
+        Arc::new(Config::default()),
+        download_receiver,
+        download_sender.clone(),
+        (message_sender, 0),
+        cancel.clone(),
+        1,
+    );
+
+    download_sender
+        .send(download.clone())
+        .await
+        .expect("enqueue paused restored download");
+
+    wait_for_paused(&download).await;
+    sleep(Duration::from_millis(150)).await;
+    assert_eq!(driver.call_count(), 0, "paused download invoked driver");
+    assert!(
+        message_receiver.try_recv().is_err(),
+        "paused download became active before resume"
+    );
+
+    download.resume();
+
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Active { .. }
+    ));
+    assert!(matches!(
+        next_message(&mut message_receiver).await,
+        RunnerMessage::Inactive { .. }
+    ));
+    assert_eq!(driver.call_count(), 1);
 
     cancel.cancel();
     for worker in workers {


### PR DESCRIPTION
## Summary
- persist queued download metadata across application closes
- restore valid partial downloads on startup
- add settings toggle and coverage for persistence/resume behavior

## Validation
- cargo fmt -- --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings