### PR TITLE
ci: use cached cargo-nextest

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Install Linux system dependencies
         run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
 
+      - name: Install cargo-nextest
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-nextest
+          locked: true
+
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2
 
@@ -36,4 +42,4 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Run tests
-        run: cargo test --all-features --verbose
+        run: cargo nextest run --all-features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 ## Development Rules
 
 - Run `cargo fmt` and `cargo clippy` after editing Rust code, resolve lints where reasonable.
+- Prefer `cargo nextest run` for Rust tests when `cargo-nextest` is available; otherwise use `cargo test`.
 
 ## Test Quality Policy
 


### PR DESCRIPTION
## Summary

CI now runs Rust tests with `cargo-nextest` and caches the installed binary through the documented `cargo-install` action. Repository guidance matches this preference while retaining `cargo test` as the fallback when nextest is unavailable.

## Validation

- `cargo nextest run --all-features`: 52 passed
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`

## New concepts

### Cached cargo-nextest installation

The `baptiste0928/cargo-install` action caches compiled Cargo-installed binaries, so CI can reuse `cargo-nextest` without rebuilding it on every run. This is separate from `Swatinem/rust-cache`, which caches project dependencies and build artifacts.

Use this pattern for tools installed from Cargo when a reproducible, cached binary is preferable to compiling the tool during every workflow run.
