### PR TITLE
ci: install cargo-nextest with taiki-e action

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -27,10 +27,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
 
       - name: Install cargo-nextest
-        uses: baptiste0928/cargo-install@v3
+        uses: taiki-e/install-action@v2
         with:
-          crate: cargo-nextest
-          locked: true
+          tool: nextest
 
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Install Linux system dependencies
         run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
 
+      - name: Install cargo-nextest
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-nextest
+          locked: true
+
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2
 
@@ -36,4 +42,4 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Run tests
-        run: cargo test --all-features --verbose
+        run: cargo nextest run --all-features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 ## Development Rules
 
 - Run `cargo fmt` and `cargo clippy` after editing Rust code, resolve lints where reasonable.
+- Prefer `cargo nextest run` for Rust tests when `cargo-nextest` is available; otherwise use `cargo test`.
 
 ## Test Quality Policy
 


### PR DESCRIPTION
CI now installs cargo-nextest from taiki-e's prebuilt release action instead of compiling it through cargo-install, keeping the existing `cargo nextest run --all-features` test command unchanged.

Validation: YAML diagnostics pass for `.github/workflows/code-quality.yml`.
