### PR TITLE
Align download progress columns and add UI customization

### DIFF
--- a/docs/solutions/design-patterns/iced-update-check-settings-layout-2026-06-10.md
+++ b/docs/solutions/design-patterns/iced-update-check-settings-layout-2026-06-10.md
@@ -35,7 +35,7 @@ The final branch separates the work into four concerns:
 - `src/update_check.rs` owns GitHub release fetching and version comparison.
 - `src/config.rs` persists the user's automatic-check preference without breaking existing `config.json` files.
 - `src/app.rs` schedules async checks, decides which results are silent or visible, and owns modal state.
-- `src/app/screens/settings.rs` and `src/app/components/error_modal.rs` present the settings controls and update modal.
+- `src/app/screens/settings.rs` and `src/app/components/modal.rs` present the settings controls and update modal.
 
 The branch also surfaced a few practical pitfalls: Iced 0.14 uses `checkbox(state).label(...).on_toggle(...)`, not a label-first checkbox helper; update-available should be modeled as structured app state rather than folded into generic error text; and a raw release URL in modal copy is less useful than a clear `Open release` button.
 
@@ -96,7 +96,7 @@ match result {
 }
 ```
 
-For settings layout, place the update preference and manual action together as one final settings row above the generic Save/Reset controls. Keep the button fixed-width so the label does not wrap or jitter.
+For settings layout, place the update preference and manual action together in the General section above the generic Save/Reset controls, but give each its own aligned row. Keep the button fixed-width so its label does not wrap or jitter.
 
 ```rust
 Row::new()
@@ -109,9 +109,24 @@ Row::new()
     )
     .push(space::horizontal())
     .push(
-        button("Check now")
-            .width(Length::Fixed(120_f32))
+        button("Check for updates")
+            .width(Length::Fixed(170_f32))
             .style(styles::button::primary)
+            .on_press(Message::CheckForUpdates),
+    )
+```
+
+When checkbox controls use a label-left/control-right layout, keep the checkbox and manual action in separate rows:
+
+```rust
+settings_checkbox("Automatically check for updates", self.config.check_for_updates)
+
+Row::new()
+    .height(Length::Fixed(30_f32))
+    .push(space::horizontal())
+    .push(
+        button("Check for updates")
+            .width(Length::Fixed(170_f32))
             .on_press(Message::CheckForUpdates),
     )
 ```
@@ -214,7 +229,7 @@ impl UpdateCheckError {
 
 ### Put update controls where users expect app-level preferences
 
-The update checkbox and manual action belong together as the last settings row, not between existing transfer/proxy tuning controls and not split between the form body and the bottom Save/Reset row.
+The update checkbox and manual action belong together in the General section, not between existing transfer/proxy tuning controls and not split between the form body and the bottom Save/Reset row. Use separate aligned rows when checkbox controls are right-aligned.
 
 ```rust
 .push(self.proxy_selector())
@@ -241,7 +256,7 @@ button(" Open release ")
 - `src/config.rs` - persisted `check_for_updates` defaulting.
 - `src/app.rs` and `src/app/helpers.rs` - Iced task routing, app-owned modal state, and message definitions.
 - `src/app/screens/settings.rs` - final-row settings placement and fixed-width action button.
-- `src/app/components/error_modal.rs` - existing generic modal plus update-specific modal.
+- `src/app/components/modal.rs` - existing generic modal plus update-specific modal.
 - `docs/solutions/best-practices/session-centered-transfer-core-2026-04-18.md` - adjacent pattern for keeping surfaces thin over shared logic; overlap is low, but the same principle applies here.
 
 External references that informed the captured pattern:

--- a/docs/solutions/ui-bugs/settings-page-layout-and-control-alignment.md
+++ b/docs/solutions/ui-bugs/settings-page-layout-and-control-alignment.md
@@ -1,0 +1,122 @@
+---
+title: Fix Settings Page Layout and Control Alignment
+date: 2026-08-09
+category: ui-bugs
+module: settings
+problem_type: ui_bug
+component: tooling
+severity: medium
+symptoms:
+  - "Settings rows and spacers spread across the entire window instead of staying in a compact form column"
+  - "The settings scrollbar appeared inside the content instead of at the far-right edge of the pane"
+  - "Checkbox controls were not aligned with their labels and the Theme row used a different left inset"
+  - "The manual update action was presented inline with the automatic-update checkbox"
+root_cause: scope_issue
+resolution_type: code_fix
+related_components:
+  - app
+  - iced
+  - config
+tags:
+  - iced
+  - settings-ui
+  - layout
+  - scrollable
+  - checkbox
+  - ui-customization
+---
+
+# Fix Settings Page Layout and Control Alignment
+
+## Problem
+
+The Settings screen needed to add Network, General, and UI Customization sections without losing the compact control-column layout. Iterative fixes exposed a sizing conflict: the scrollbar needed the full content pane width, while the actual settings rows needed a stable maximum width.
+
+## Symptoms
+
+- A fixed-width outer settings column kept the scrollbar well inside a wide window rather than at the pane edge.
+- Making the entire settings column fill available width moved the scrollbar correctly but caused row spacers to expand with the window, pushing fixed-width controls to the far edge.
+- Checkbox builders with embedded labels placed the checkboxes before the text instead of matching the label-left/control-right layout used by other settings rows.
+- Checkbox controls sat high in their rows until the row used vertical alignment.
+- The Theme row started without the 8px inset used by sliders, pick lists, and checkbox rows.
+- The manual update button was initially combined with the automatic-update checkbox and used the shorter label `Check now`.
+
+## What Didn't Work
+
+- **Fixed-width outer pane:** Constraining the whole Settings view to `Length::Fixed(350_f32)` kept controls compact, but the scrollbar belonged to that same narrow element and therefore did not reach the right edge of the available pane.
+- **Full-width control column:** Changing the outer column to `Length::Fill` fixed scrollbar placement, but its child rows also resolved their flexible spacers against the full window width. Fixed-width controls were pushed to the far edge, leaving excessive separation and a visually stretched form.
+- **Labeled checkbox widgets:** Using `checkbox(value).label(label)` preserved the default widget composition, but it could not produce the required label-left/control-right arrangement.
+- **Coordinate-only visual debugging:** During this session, the native Iced app launched under Xvfb, but reliable automated navigation from Home to Settings was unavailable in this environment. The final change was therefore validated with source inspection and automated Rust checks rather than an unverified rendered Settings capture.
+
+## Solution
+
+Keep the scrollable viewport full width, but cap only the content column that contains the settings sections:
+
+```rust
+const SETTINGS_CONTENT_MAX_WIDTH: f32 = 350.0;
+
+scrollable(
+    Column::new().width(Length::Fill).spacing(16).push(
+        container(
+            Column::new()
+                .width(Length::Fill)
+                .push(network_settings)
+                .push(general_settings)
+                .push(ui_customization),
+        )
+        .width(Length::Fill)
+        .max_width(SETTINGS_CONTENT_MAX_WIDTH),
+    ),
+)
+.width(Length::Fill)
+.height(Length::Fill)
+```
+
+This keeps the scrollbar attached to the full pane while resolving each settings row against the capped inner column. Keep Save/Apply/Reset outside the scrollable.
+
+Use a shared row shape for checkbox settings instead of embedding labels in the checkbox widget:
+
+```rust
+Row::new()
+    .height(Length::Fixed(30_f32))
+    .align_y(Alignment::Center)
+    .push(space::horizontal().width(Length::Fixed(8_f32)))
+    .push(text(label).align_y(Vertical::Center).height(Length::Fill))
+    .push(space::horizontal())
+    .push(checkbox(is_checked).on_toggle(on_toggle))
+```
+
+Give Theme the same initial inset, and keep the manual update action as a separate right-aligned button row:
+
+```rust
+Row::new()
+    .height(Length::Fixed(30_f32))
+    .push(space::horizontal())
+    .push(
+        button("Check for updates")
+            .width(Length::Fixed(170_f32))
+            .on_press(Message::CheckForUpdates),
+    )
+```
+
+The layout and widget-message implementation lives in `src/app/screens/settings.rs:239-459`; `src/app.rs:409-420` converts the resulting `Action::CheckForUpdates` into the existing manual update task.
+
+## Why This Works
+
+Scrollable geometry and content geometry have separate responsibilities. The scrollable must fill the available pane so its scrollbar is positioned at the pane boundary. The inner content container must be capped so flexible row spacers resolve against a predictable form width instead of the entire window.
+
+The checkbox helper makes alignment explicit: the label stays at the left inset, a spacer consumes remaining row space, and the unlabeled checkbox stays at the right control edge. `Row::align_y(Alignment::Center)` centers the checkbox's intrinsic height against the text row. Applying the same 8px inset to Theme removes the last one-off row geometry.
+
+## Prevention
+
+- Treat scrollable viewport width and form content width as separate layout decisions in Iced screens.
+- Keep a named max-width constant for compact settings forms rather than repeating an anonymous fixed width.
+- Use one helper for repeated label-left/control-right checkbox rows so those settings remain consistent with sibling pick-list and slider geometry.
+- Add a manual wide-window check whenever a settings pane combines a right-edge scrollbar with fixed-width controls.
+- Preserve a characterization test for action-only settings messages, such as `Message::CheckForUpdates -> Action::CheckForUpdates`, while changing layout.
+- For native UI QA, prefer a deterministic route/startup hook or a framework-specific inspector. Do not infer rendered success from a launch-only smoke test.
+
+## Related Issues
+
+- `../design-patterns/iced-update-check-settings-layout-2026-06-10.md` covers the earlier update-check flow. This learning supersedes its recommendation to keep the automatic checkbox and manual action in one row, while extending the remaining guidance with scroll ownership, max-width geometry, and control alignment.
+- `src/app/screens/settings.rs` is the source of truth for the current layout and message bindings.

--- a/src/app.rs
+++ b/src/app.rs
@@ -502,7 +502,14 @@ impl App {
     fn view(&self) -> Element<'_, Message> {
         // build content
         let content = match self.route {
-            Route::Home => container(self.home.view().map(Message::Home)),
+            Route::Home => container(
+                self.home
+                    .view(components::download_item::DisplayPreferences {
+                        show_progress_bars: self.settings.config.show_progress_bars,
+                        show_download_sizes: self.settings.config.show_download_sizes,
+                    })
+                    .map(Message::Home),
+            ),
             Route::Import => container(self.import.view().map(Message::Import)),
             Route::ChooseFiles => {
                 if let Some(choose_files) = &self.choose_files {

--- a/src/app/components/download_item.rs
+++ b/src/app/components/download_item.rs
@@ -15,7 +15,21 @@ pub(crate) enum Message {
     Cancel(String),
 }
 
-pub(crate) fn download_item(download: &'_ Download, index: usize) -> Element<'_, Message> {
+#[derive(Clone, Copy)]
+pub(crate) struct DisplayPreferences {
+    pub(crate) show_progress_bars: bool,
+    pub(crate) show_download_sizes: bool,
+}
+
+const PROGRESS_COLUMN_WIDTH: f32 = 80.0;
+const SIZE_COLUMN_WIDTH: f32 = 105.0;
+const SPEED_COLUMN_WIDTH: f32 = 90.0;
+
+pub(crate) fn download_item(
+    download: &'_ Download,
+    index: usize,
+    preferences: DisplayPreferences,
+) -> Element<'_, Message> {
     let mut progress = download.progress();
     if progress < 0.1 && progress > 0_f32 {
         progress = 0.1;
@@ -37,56 +51,66 @@ pub(crate) fn download_item(download: &'_ Download, index: usize) -> Element<'_,
         )
     };
 
-    container(
-        Row::new()
-            .height(Length::Fixed(35_f32))
-            .width(Length::Fill)
-            .align_y(Alignment::Center)
-            .push(space::horizontal().width(Length::Fixed(7_f32)))
-            .push(
-                text(&download.node.name)
-                    .width(Length::Fill)
-                    .height(Length::Fill)
-                    .align_y(Vertical::Center),
-            )
+    let mut row = Row::new()
+        .height(Length::Fixed(35_f32))
+        .width(Length::Fill)
+        .align_y(Alignment::Center)
+        .push(space::horizontal().width(Length::Fixed(7_f32)))
+        .push(
+            text(&download.node.name)
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .align_y(Vertical::Center),
+        );
+
+    if preferences.show_progress_bars {
+        row = row
             .push(space::horizontal().width(Length::Fixed(3_f32)))
             .push(
                 progress_bar(0_f32..=1_f32, progress)
                     .style(styles::progress_bar::custom_style)
-                    .length(Length::Fixed(80_f32))
+                    .length(Length::Fixed(PROGRESS_COLUMN_WIDTH))
                     .girth(Length::Fixed(15_f32)),
             )
-            .push(space::horizontal().width(Length::Fixed(10_f32)))
+            .push(space::horizontal().width(Length::Fixed(10_f32)));
+    }
+
+    if preferences.show_download_sizes {
+        row = row
             .push(
                 text({
                     let downloaded = download.downloaded.load(Ordering::Relaxed) as u64;
                     let total = download.node.size;
                     format!("{}/{}", format_size(downloaded), format_size(total)).replace('0', "O")
                 })
-                .width(Length::Shrink)
+                .width(Length::Fixed(SIZE_COLUMN_WIDTH))
                 .height(Length::Fill)
                 .align_y(Vertical::Center)
                 .font(MONOSPACE)
                 .size(13),
             )
-            .push(space::horizontal().width(Length::Fixed(6_f32)))
-            .push(
-                text(format!("{} MB/s", pad_f32(download.speed())).replace('0', "O"))
-                    .width(Length::Shrink)
-                    .height(Length::Fill)
-                    .align_y(Vertical::Center)
-                    .font(MONOSPACE)
-                    .size(16),
-            )
-            .push(space::horizontal().width(Length::Fixed(5_f32)))
-            .push(icon_button(
-                X_ICON,
-                Message::Cancel(id.clone()),
-                styles::svg::primary_svg,
-            ))
-            .push(pause_button)
-            .push(space::horizontal().width(Length::Fixed(7_f32))),
-    )
-    .style(styles::container::download_style(index))
-    .into()
+            .push(space::horizontal().width(Length::Fixed(6_f32)));
+    }
+
+    row = row
+        .push(
+            text(format!("{} MB/s", pad_f32(download.speed())).replace('0', "O"))
+                .width(Length::Fixed(SPEED_COLUMN_WIDTH))
+                .height(Length::Fill)
+                .align_y(Vertical::Center)
+                .font(MONOSPACE)
+                .size(16),
+        )
+        .push(space::horizontal().width(Length::Fixed(5_f32)))
+        .push(icon_button(
+            X_ICON,
+            Message::Cancel(id.clone()),
+            styles::svg::primary_svg,
+        ))
+        .push(pause_button)
+        .push(space::horizontal().width(Length::Fixed(7_f32)));
+
+    container(row)
+        .style(styles::container::download_style(index))
+        .into()
 }

--- a/src/app/screens/home.rs
+++ b/src/app/screens/home.rs
@@ -114,17 +114,22 @@ impl Home {
         }
     }
 
-    pub(crate) fn view(&self) -> Element<'_, Message> {
+    pub(crate) fn view(
+        &self,
+        display_preferences: download_item::DisplayPreferences,
+    ) -> Element<'_, Message> {
         let mut download_list = Column::new();
 
         for (index, (_id, download)) in self.active_downloads.iter().enumerate() {
-            download_list = download_list.push(download_item::download_item(download, index).map(
-                |msg| match msg {
-                    download_item::Message::Pause(id) => Message::PauseDownload(id),
-                    download_item::Message::Resume(id) => Message::ResumeDownload(id),
-                    download_item::Message::Cancel(id) => Message::CancelDownload(id),
-                },
-            ));
+            download_list = download_list.push(
+                download_item::download_item(download, index, display_preferences).map(|msg| {
+                    match msg {
+                        download_item::Message::Pause(id) => Message::PauseDownload(id),
+                        download_item::Message::Resume(id) => Message::ResumeDownload(id),
+                        download_item::Message::Cancel(id) => Message::CancelDownload(id),
+                    }
+                }),
+            );
         }
 
         if self.active_downloads.is_empty() {

--- a/src/app/screens/settings.rs
+++ b/src/app/screens/settings.rs
@@ -39,6 +39,8 @@ pub(crate) enum Message {
     RebuildMega,
     CheckForUpdatesChanged(bool),
     PersistDownloadSessionsChanged(bool),
+    ShowProgressBarsChanged(bool),
+    ShowDownloadSizesChanged(bool),
     CheckForUpdates,
 }
 
@@ -157,6 +159,14 @@ impl Settings {
                 self.config.persist_download_sessions = enabled;
                 Action::None
             }
+            Message::ShowProgressBarsChanged(enabled) => {
+                self.config.show_progress_bars = enabled;
+                Action::None
+            }
+            Message::ShowDownloadSizesChanged(enabled) => {
+                self.config.show_download_sizes = enabled;
+                Action::None
+            }
             Message::ProxyModeChanged(proxy_mode) => {
                 if proxy_mode == ProxyMode::Single {
                     self.config.proxies.truncate(1);
@@ -231,106 +241,122 @@ impl Settings {
             apply_button = apply_button.on_press(Message::RebuildMega);
         }
 
+        let network_settings = Column::new()
+            .spacing(8)
+            .push(text("Network").size(20))
+            .push(self.settings_slider(
+                0,
+                self.config.max_workers,
+                MIN_MAX_WORKERS as f64..=MAX_MAX_WORKERS as f64,
+                "Max Workers:",
+            ))
+            .push(self.settings_slider(
+                1,
+                self.config.concurrency_budget,
+                MIN_CONCURRENCY as f64..=MAX_CONCURRENCY as f64,
+                "Concurrency Budget:",
+            ))
+            .push(self.settings_slider(
+                2,
+                self.config.timeout.as_millis() as usize,
+                100_f64..=60000_f64,
+                "Timeout:",
+            ))
+            .push(self.settings_slider(
+                3,
+                self.config.max_retries as usize,
+                1_f64..=10_f64,
+                "Max retries:",
+            ))
+            .push(self.settings_slider(
+                4,
+                self.config.min_retry_delay.as_millis() as usize,
+                100_f64..=self.config.max_retry_delay.as_millis() as f64,
+                "Min Retry delay:",
+            ))
+            .push(self.settings_slider(
+                5,
+                self.config.max_retry_delay.as_millis() as usize,
+                self.config.min_retry_delay.as_millis() as f64..=60000_f64,
+                "Max Retry delay:",
+            ))
+            .push(self.settings_picklist(
+                "Proxy Mode",
+                &ProxyMode::ALL[..],
+                Some(self.config.proxy_mode),
+                Message::ProxyModeChanged,
+            ))
+            .push(self.proxy_selector());
+
+        let general_settings = Column::new()
+            .spacing(8)
+            .push(text("General").size(20))
+            .push(
+                checkbox(self.config.persist_download_sessions)
+                    .label("Restore downloads after closing")
+                    .on_toggle(Message::PersistDownloadSessionsChanged),
+            )
+            .push(
+                Row::new()
+                    .height(Length::Fixed(30_f32))
+                    .push(
+                        checkbox(self.config.check_for_updates)
+                            .label("Automatically check for updates")
+                            .on_toggle(Message::CheckForUpdatesChanged),
+                    )
+                    .push(space::horizontal())
+                    .push(
+                        button("Check now")
+                            .width(Length::Fixed(120_f32))
+                            .style(styles::button::primary)
+                            .on_press(Message::CheckForUpdates),
+                    ),
+            );
+
+        let ui_customization = Column::new()
+            .spacing(8)
+            .push(text("UI Customization").size(20))
+            .push(
+                Row::new()
+                    .height(Length::Fixed(30_f32))
+                    .push(text("Theme").align_y(Vertical::Center).height(Length::Fill))
+                    .push(space::horizontal())
+                    .push(
+                        pick_list(
+                            self.theme_options.clone(),
+                            Some(self.config.theme.clone()),
+                            Message::ThemeChanged,
+                        )
+                        .width(Length::Fixed(170_f32))
+                        .style(styles::pick_list::default),
+                    ),
+            )
+            .push(
+                checkbox(self.config.show_progress_bars)
+                    .label("Show download progress bars")
+                    .on_toggle(Message::ShowProgressBarsChanged),
+            )
+            .push(
+                checkbox(self.config.show_download_sizes)
+                    .label("Show download sizes")
+                    .on_toggle(Message::ShowDownloadSizesChanged),
+            );
+
         container(
             Column::new()
                 .width(Length::Fixed(350_f32))
-                .push(self.settings_slider(
-                    0,
-                    self.config.max_workers,
-                    MIN_MAX_WORKERS as f64..=MAX_MAX_WORKERS as f64,
-                    "Max Workers:",
-                ))
-                .push(self.settings_slider(
-                    1,
-                    self.config.concurrency_budget,
-                    MIN_CONCURRENCY as f64..=MAX_CONCURRENCY as f64,
-                    "Concurrency Budget:",
-                ))
-                .push(self.settings_slider(
-                    2,
-                    self.config.timeout.as_millis() as usize,
-                    100_f64..=60000_f64,
-                    "Timeout:",
-                ))
-                .push(self.settings_slider(
-                    3,
-                    self.config.max_retries as usize,
-                    1_f64..=10_f64,
-                    "Max retries:",
-                ))
-                .push(self.settings_slider(
-                    4,
-                    self.config.min_retry_delay.as_millis() as usize,
-                    100_f64..=self.config.max_retry_delay.as_millis() as f64,
-                    "Min Retry delay:",
-                ))
-                .push(self.settings_slider(
-                    5,
-                    self.config.max_retry_delay.as_millis() as usize,
-                    self.config.min_retry_delay.as_millis() as f64..=60000_f64,
-                    "Max Retry delay:",
-                ))
-                .push(space::vertical().height(Length::Fixed(10_f32)))
+                .height(Length::Fill)
+                .spacing(10)
                 .push(
-                    Row::new()
-                        .height(Length::Fixed(30_f32))
-                        .push(space::horizontal().width(Length::Fixed(8_f32)))
-                        .push(text("Theme").align_y(Vertical::Center).height(Length::Fill))
-                        .push(space::horizontal())
-                        .push(
-                            pick_list(
-                                self.theme_options.clone(),
-                                Some(self.config.theme.clone()),
-                                Message::ThemeChanged,
-                            )
-                            .width(Length::Fixed(170_f32))
-                            .style(styles::pick_list::default),
-                        ),
+                    scrollable(
+                        Column::new()
+                            .spacing(16)
+                            .push(network_settings)
+                            .push(general_settings)
+                            .push(ui_customization),
+                    )
+                    .height(Length::Fill),
                 )
-                .push(space::vertical().height(Length::Fixed(10_f32)))
-                .push(self.settings_picklist(
-                    "Proxy Mode",
-                    &ProxyMode::ALL[..],
-                    Some(self.config.proxy_mode),
-                    Message::ProxyModeChanged,
-                ))
-                .push(space::vertical().height(Length::Fixed(10_f32)))
-                .push(self.proxy_selector())
-                .push(space::vertical().height(Length::Fixed(8_f32)))
-                .push(
-                    Row::new()
-                        .height(Length::Fixed(30_f32))
-                        .push(space::horizontal().width(Length::Fixed(8_f32)))
-                        .push(
-                            checkbox(self.config.persist_download_sessions)
-                                .label("Restore downloads after closing")
-                                .on_toggle(Message::PersistDownloadSessionsChanged),
-                        ),
-                )
-                .push(space::vertical().height(Length::Fixed(8_f32)))
-                .push(
-                    Row::new()
-                        .height(Length::Fixed(30_f32))
-                        .push(space::horizontal().width(Length::Fixed(8_f32)))
-                        .push(
-                            Column::new()
-                                .push(space::vertical().height(Length::Fill))
-                                .push(
-                                    checkbox(self.config.check_for_updates)
-                                        .label("Automatically check for updates")
-                                        .on_toggle(Message::CheckForUpdatesChanged),
-                                )
-                                .push(space::vertical().height(Length::Fill)),
-                        )
-                        .push(space::horizontal().width(Length::Fixed(5_f32)))
-                        .push(
-                            button("Check now")
-                                .width(Length::Fixed(120_f32))
-                                .style(styles::button::primary)
-                                .on_press(Message::CheckForUpdates),
-                        ),
-                )
-                .push(space::vertical().height(Length::Fill))
                 .push(
                     Row::new()
                         .push(space::horizontal().width(Length::Fixed(8_f32)))
@@ -497,5 +523,22 @@ mod tests {
             Action::None
         ));
         assert!(settings.config.persist_download_sessions);
+    }
+
+    #[test]
+    fn display_preferences_toggle_without_rebuild() {
+        let mut settings = Settings::new(Config::default());
+
+        assert!(matches!(
+            settings.update(Message::ShowProgressBarsChanged(false)),
+            Action::None
+        ));
+        assert!(matches!(
+            settings.update(Message::ShowDownloadSizesChanged(false)),
+            Action::None
+        ));
+        assert!(!settings.config.show_progress_bars);
+        assert!(!settings.config.show_download_sizes);
+        assert!(!settings.rebuild_available);
     }
 }

--- a/src/app/screens/settings.rs
+++ b/src/app/screens/settings.rs
@@ -9,7 +9,7 @@ use iced::widget::{
     Column, Row, button, checkbox, container, pick_list, scrollable, slider, space, svg, text,
     text_input,
 };
-use iced::{Element, Length, Theme};
+use iced::{Alignment, Element, Length, Theme};
 use native_dialog::FileDialogBuilder;
 use num_traits::cast::ToPrimitive;
 use std::borrow::Cow;
@@ -304,12 +304,6 @@ impl Settings {
             .push(
                 Row::new()
                     .height(Length::Fixed(30_f32))
-                    .push(space::horizontal().width(Length::Fixed(8_f32)))
-                    .push(
-                        text("Check for updates")
-                            .align_y(Vertical::Center)
-                            .height(Length::Fill),
-                    )
                     .push(space::horizontal())
                     .push(
                         button("Check for updates")
@@ -350,7 +344,7 @@ impl Settings {
 
         container(
             Column::new()
-                .width(Length::Fixed(350_f32))
+                .width(Length::Fill)
                 .height(Length::Fill)
                 .spacing(10)
                 .push(
@@ -449,6 +443,7 @@ impl Settings {
     ) -> Element<'a, Message> {
         Row::new()
             .height(Length::Fixed(30_f32))
+            .align_y(Alignment::Center)
             .push(space::horizontal().width(Length::Fixed(8_f32)))
             .push(text(label).align_y(Vertical::Center).height(Length::Fill))
             .push(space::horizontal())

--- a/src/app/screens/settings.rs
+++ b/src/app/screens/settings.rs
@@ -291,23 +291,29 @@ impl Settings {
         let general_settings = Column::new()
             .spacing(8)
             .push(text("General").size(20))
-            .push(
-                checkbox(self.config.persist_download_sessions)
-                    .label("Restore downloads after closing")
-                    .on_toggle(Message::PersistDownloadSessionsChanged),
-            )
+            .push(self.settings_checkbox(
+                "Restore downloads after closing",
+                self.config.persist_download_sessions,
+                Message::PersistDownloadSessionsChanged,
+            ))
+            .push(self.settings_checkbox(
+                "Automatically check for updates",
+                self.config.check_for_updates,
+                Message::CheckForUpdatesChanged,
+            ))
             .push(
                 Row::new()
                     .height(Length::Fixed(30_f32))
+                    .push(space::horizontal().width(Length::Fixed(8_f32)))
                     .push(
-                        checkbox(self.config.check_for_updates)
-                            .label("Automatically check for updates")
-                            .on_toggle(Message::CheckForUpdatesChanged),
+                        text("Check for updates")
+                            .align_y(Vertical::Center)
+                            .height(Length::Fill),
                     )
                     .push(space::horizontal())
                     .push(
-                        button("Check now")
-                            .width(Length::Fixed(120_f32))
+                        button("Check for updates")
+                            .width(Length::Fixed(170_f32))
                             .style(styles::button::primary)
                             .on_press(Message::CheckForUpdates),
                     ),
@@ -331,16 +337,16 @@ impl Settings {
                         .style(styles::pick_list::default),
                     ),
             )
-            .push(
-                checkbox(self.config.show_progress_bars)
-                    .label("Show download progress bars")
-                    .on_toggle(Message::ShowProgressBarsChanged),
-            )
-            .push(
-                checkbox(self.config.show_download_sizes)
-                    .label("Show download sizes")
-                    .on_toggle(Message::ShowDownloadSizesChanged),
-            );
+            .push(self.settings_checkbox(
+                "Show download progress bars",
+                self.config.show_progress_bars,
+                Message::ShowProgressBarsChanged,
+            ))
+            .push(self.settings_checkbox(
+                "Show download sizes",
+                self.config.show_download_sizes,
+                Message::ShowDownloadSizesChanged,
+            ));
 
         container(
             Column::new()
@@ -350,11 +356,13 @@ impl Settings {
                 .push(
                     scrollable(
                         Column::new()
+                            .width(Length::Fill)
                             .spacing(16)
                             .push(network_settings)
                             .push(general_settings)
                             .push(ui_customization),
                     )
+                    .width(Length::Fill)
                     .height(Length::Fill),
                 )
                 .push(
@@ -430,6 +438,21 @@ impl Settings {
                     .width(Length::Fixed(170_f32))
                     .style(styles::pick_list::default),
             )
+            .into()
+    }
+
+    fn settings_checkbox<'a>(
+        &self,
+        label: &'a str,
+        is_checked: bool,
+        on_toggle: fn(bool) -> Message,
+    ) -> Element<'a, Message> {
+        Row::new()
+            .height(Length::Fixed(30_f32))
+            .push(space::horizontal().width(Length::Fixed(8_f32)))
+            .push(text(label).align_y(Vertical::Center).height(Length::Fill))
+            .push(space::horizontal())
+            .push(checkbox(is_checked).on_toggle(on_toggle))
             .into()
     }
 
@@ -540,5 +563,15 @@ mod tests {
         assert!(!settings.config.show_progress_bars);
         assert!(!settings.config.show_download_sizes);
         assert!(!settings.rebuild_available);
+    }
+
+    #[test]
+    fn check_for_updates_returns_check_for_updates_action() {
+        let mut settings = Settings::new(Config::default());
+
+        assert!(matches!(
+            settings.update(Message::CheckForUpdates),
+            Action::CheckForUpdates
+        ));
     }
 }

--- a/src/app/screens/settings.rs
+++ b/src/app/screens/settings.rs
@@ -18,6 +18,8 @@ use std::ops::RangeInclusive;
 use std::time::Duration;
 use url::Url;
 
+const SETTINGS_CONTENT_MAX_WIDTH: f32 = 350.0;
+
 #[derive(Clone)]
 pub(crate) struct Settings {
     pub(crate) config: Config,
@@ -319,6 +321,7 @@ impl Settings {
             .push(
                 Row::new()
                     .height(Length::Fixed(30_f32))
+                    .push(space::horizontal().width(Length::Fixed(8_f32)))
                     .push(text("Theme").align_y(Vertical::Center).height(Length::Fill))
                     .push(space::horizontal())
                     .push(
@@ -349,12 +352,17 @@ impl Settings {
                 .spacing(10)
                 .push(
                     scrollable(
-                        Column::new()
+                        Column::new().width(Length::Fill).spacing(16).push(
+                            container(
+                                Column::new()
+                                    .width(Length::Fill)
+                                    .push(network_settings)
+                                    .push(general_settings)
+                                    .push(ui_customization),
+                            )
                             .width(Length::Fill)
-                            .spacing(16)
-                            .push(network_settings)
-                            .push(general_settings)
-                            .push(ui_customization),
+                            .max_width(SETTINGS_CONTENT_MAX_WIDTH),
+                        ),
                     )
                     .width(Length::Fill)
                     .height(Length::Fill),

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,12 @@ pub(crate) struct Config {
     #[cfg(feature = "gui")]
     #[serde(default)]
     pub(crate) persist_download_sessions: bool,
+    #[cfg(feature = "gui")]
+    #[serde(default = "default_display_preference")]
+    pub(crate) show_progress_bars: bool,
+    #[cfg(feature = "gui")]
+    #[serde(default = "default_display_preference")]
+    pub(crate) show_download_sizes: bool,
     pub(crate) max_workers: usize,
     pub(crate) concurrency_budget: usize,
     pub(crate) max_retries: u32,
@@ -87,6 +93,10 @@ impl Default for Config {
             check_for_updates: default_check_for_updates(),
             #[cfg(feature = "gui")]
             persist_download_sessions: false,
+            #[cfg(feature = "gui")]
+            show_progress_bars: default_display_preference(),
+            #[cfg(feature = "gui")]
+            show_download_sizes: default_display_preference(),
             max_workers: 10,
             concurrency_budget: 10,
             max_retries: 3,
@@ -199,6 +209,11 @@ impl Config {
 
 #[cfg(feature = "gui")]
 fn default_check_for_updates() -> bool {
+    true
+}
+
+#[cfg(feature = "gui")]
+fn default_display_preference() -> bool {
     true
 }
 
@@ -341,4 +356,44 @@ fn save_default() -> Config {
         error!("Failed to save default config: {save_error}",);
     }
     config
+}
+
+#[cfg(all(test, feature = "gui"))]
+mod tests {
+    use super::Config;
+
+    #[test]
+    fn display_preferences_default_to_visible() {
+        let config = Config::default();
+
+        assert!(config.show_progress_bars);
+        assert!(config.show_download_sizes);
+    }
+
+    #[test]
+    fn legacy_config_missing_display_preferences_defaults_to_visible() {
+        let mut legacy_config = serde_json::to_value(Config::default()).unwrap();
+        let fields = legacy_config.as_object_mut().unwrap();
+        fields.remove("show_progress_bars");
+        fields.remove("show_download_sizes");
+
+        let config: Config = serde_json::from_value(legacy_config).unwrap();
+
+        assert!(config.show_progress_bars);
+        assert!(config.show_download_sizes);
+    }
+
+    #[test]
+    fn disabled_display_preferences_round_trip() {
+        let config = Config {
+            show_progress_bars: false,
+            show_download_sizes: false,
+            ..Config::default()
+        };
+
+        let config: Config = serde_json::from_value(serde_json::to_value(config).unwrap()).unwrap();
+
+        assert!(!config.show_progress_bars);
+        assert!(!config.show_download_sizes);
+    }
 }


### PR DESCRIPTION
## Summary
Download rows now keep their progress bars in one stable column instead of shifting with variable size and speed text. Settings now groups controls into Network, General, and UI Customization, with persisted options for showing progress bars and download sizes and the theme picker in the customization section.

New display preferences default to enabled and remain compatible with existing config files that do not contain these fields.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --features gui` (56 passed)
- `cargo test --no-default-features` (41 passed)
- `cargo clippy --all-targets --features gui -- -D warnings`
- GUI startup smoke test under `xvfb-run`
